### PR TITLE
Record user-agent info

### DIFF
--- a/packages/itmat-commons/src/graphql/log.ts
+++ b/packages/itmat-commons/src/graphql/log.ts
@@ -18,6 +18,7 @@ export const GET_LOGS = gql`
             id,
             requesterName,
             requesterType,
+            userAgent,
             logType,
             actionType,
             actionData,

--- a/packages/itmat-commons/src/models/log.ts
+++ b/packages/itmat-commons/src/models/log.ts
@@ -4,12 +4,18 @@ export interface ILogEntry {
     id: string,
     requesterName: string,
     requesterType: userTypes,
+    userAgent: USER_AGENT,
     logType: LOG_TYPE,
     actionType: LOG_ACTION,
     actionData: any,
     time: number,
     status: LOG_STATUS,
     errors: string | null
+}
+
+export enum USER_AGENT {
+    MOZILLA = 'MOZILLA',
+    OTHER = 'OTHER'
 }
 
 export enum LOG_TYPE {

--- a/packages/itmat-interface/src/graphql/schema.ts
+++ b/packages/itmat-interface/src/graphql/schema.ts
@@ -172,6 +172,11 @@ enum LOG_TYPE {
    REQUEST_LOG
 }
 
+enum USER_AGENT {
+    MOZILLA,
+    OTHER
+}
+
 enum LOG_STATUS {
     SUCCESS
     FAIL
@@ -231,6 +236,7 @@ type Log {
     id: String!,
     requesterName: String,
     requesterType: USERTYPE,
+    userAgent: USER_AGENT,
     logType: LOG_TYPE,
     actionType: LOG_ACTION,
     actionData: JSON,

--- a/packages/itmat-interface/src/log/logPlugin.ts
+++ b/packages/itmat-interface/src/log/logPlugin.ts
@@ -1,6 +1,6 @@
 import { db } from '../database/database';
 import { v4 as uuid} from 'uuid';
-import { LOG_TYPE, LOG_ACTION, LOG_STATUS, userTypes } from 'itmat-commons';
+import { LOG_TYPE, LOG_ACTION, LOG_STATUS, USER_AGENT, userTypes } from 'itmat-commons';
 
 // only requests in white list will be recorded
 export const logActionRecordWhiteList = Object.keys(LOG_ACTION);
@@ -33,6 +33,7 @@ export class LogPlugin {
             id: uuid(),
             requesterName: requestContext.context.req.user ? requestContext.context.req.user.username : 'NA',
             requesterType: requestContext.context.req.user ? requestContext.context.req.user.type : userTypes.SYSTEM,
+            userAgent: (requestContext.context.req.headers['user-agent'] as string).startsWith('Mozilla') ? USER_AGENT.MOZILLA: USER_AGENT.OTHER,
             logType: LOG_TYPE.REQUEST_LOG,
             actionType: LOG_ACTION[requestContext.operationName],
             actionData: JSON.stringify(requestContext.request.variables),

--- a/packages/itmat-interface/test/serverTests/log.test.ts
+++ b/packages/itmat-interface/test/serverTests/log.test.ts
@@ -17,7 +17,8 @@ import {
     LOG_TYPE,
     LOGIN,
     IUser,
-    DELETE_USER
+    DELETE_USER,
+    USER_AGENT
 } from 'itmat-commons';
 
 let app;
@@ -139,6 +140,7 @@ describe('LOG API', () => {
                 requesterName: userTypes.SYSTEM,
                 requesterType: userTypes.SYSTEM,
                 logType: LOG_TYPE.SYSTEM_LOG,
+                userAgent: USER_AGENT.MOZILLA,
                 actionType: LOG_ACTION.startSERVER,
                 actionData: JSON.stringify({}),
                 time: 100000000,

--- a/packages/itmat-ui-react/src/components/log/logList.tsx
+++ b/packages/itmat-ui-react/src/components/log/logList.tsx
@@ -1,4 +1,4 @@
-import { Models, GET_LOGS, userTypes, LOG_ACTION, LOG_TYPE, LOG_STATUS } from 'itmat-commons';
+import { Models, GET_LOGS, userTypes, LOG_ACTION, LOG_TYPE, LOG_STATUS, USER_AGENT } from 'itmat-commons';
 import * as React from 'react';
 import { Query } from '@apollo/client/react/components';
 import LoadSpinner from '../reusable/loadSpinner';
@@ -38,6 +38,7 @@ const LogList: React.FunctionComponent<{ list: Models.Log.ILogEntry[] }> = ({ li
     const initInputs = {
         requesterName: '',
         requesterType: [],
+        userAgent: [],
         logType: [],
         actionType: [],
         time: '',
@@ -80,6 +81,7 @@ const LogList: React.FunctionComponent<{ list: Models.Log.ILogEntry[] }> = ({ li
                 || new Date(log.time).toUTCString().toUpperCase().search(searchTerm) > -1 || log.status.toUpperCase().search(searchTerm) > -1))
             && (inputs.requesterName === '' || log.requesterName.toLowerCase().indexOf(inputs.requesterName.toLowerCase()) !== -1)
             && (inputs.requesterType.length === 0 || inputs.requesterType.includes(log.requesterType))
+            && (inputs.userAgent.length === 0 || inputs.userAgent.includes(log.userAgent))
             && (inputs.logType.length === 0 || inputs.logType.includes(log.logType))
             && (inputs.actionType.length === 0 || inputs.actionType.includes(log.actionType))
             && (inputs.status.length === 0 || inputs.status.includes(log.status))
@@ -129,6 +131,20 @@ const LogList: React.FunctionComponent<{ list: Models.Log.ILogEntry[] }> = ({ li
                     }} />;
                 else
                     return record.logType;
+            }
+        },
+        {
+            title: 'Request From',
+            dataIndex: 'userAgent',
+            key: 'userAgent',
+            render: (__unused__value, record) => {
+                if (searchTerm)
+                    return <Highlighter searchWords={[searchTerm]} textToHighlight={record.userAgent} highlightStyle={{
+                        backgroundColor: '#FFC733',
+                        padding: 0
+                    }} />;
+                else
+                    return record.userAgent;
             }
         },
         {
@@ -214,6 +230,8 @@ const LogList: React.FunctionComponent<{ list: Models.Log.ILogEntry[] }> = ({ li
             <Input {...inputControl('requesterName')} style={{ marginBottom: '20px' }} />
             <Descriptions title='Requester Type'></Descriptions>
             <Checkbox.Group options={Object.keys(userTypes)} {...checkboxControl('requesterType')} style={{ marginBottom: '20px' }} />
+            <Descriptions title='Request From'></Descriptions>
+            <Checkbox.Group options={Object.keys(USER_AGENT)} {...checkboxControl('userAgent')} style={{ marginBottom: '20px' }} />
             <Descriptions title='Log Type'></Descriptions>
             <Checkbox.Group options={Object.keys(LOG_TYPE)} {...checkboxControl('logType')} style={{ marginBottom: '20px' }} />
             <Descriptions title='Request Type'></Descriptions>


### PR DESCRIPTION
Extract info of user-agent from request to dertimine the source of a query, i.e., browsers' start with _'Mozilla'_. Something to confirm:
1. The database only saves the two sources (Mozilla & Other) without recording the details (i.e., form Chrome of Safari, which I think would occupy to much sapce), is that OK and is the name 'Mozilla & Other' OK?
2. Do we need to consider if someone pretended to be using a browser by inserting a fake user-agent into the request, such as web crawler?

Log page:
![mozilla](https://user-images.githubusercontent.com/21955220/96104082-4d6e6900-0ed0-11eb-9855-0ae01e360013.png)
