### PR TITLE
new expiry date request feature

### DIFF
--- a/packages/itmat-commons/src/graphql/user.ts
+++ b/packages/itmat-commons/src/graphql/user.ts
@@ -29,8 +29,8 @@ export const user_fragment = gql`
 `;
 
 export const LOGIN = gql`
-mutation login($username: String!, $password: String!, $totp: String!) {
-  login(username: $username, password: $password, totp: $totp) {
+mutation login($username: String!, $password: String!, $totp: String!, $requestexpirydate: Boolean) {
+  login(username: $username, password: $password, totp: $totp, requestexpirydate: $requestexpirydate) {
       ...ALL_FOR_USER
   }
 }
@@ -134,6 +134,20 @@ export const CREATE_USER = gql`
 export const RECOVER_SESSION_EXPIRE_TIME = gql`
     query recoverSessionExpireTime {
         recoverSessionExpireTime {
+            successful
+        }
+    }
+`;
+
+export const REQUEST_EXPIRY_DATE = gql`
+    mutation requestExpiryDate(
+        $username: String,
+        $email: String        
+    ) {
+        requestExpiryDate(
+            username: $username,
+            email: $email
+        ) {
             successful
         }
     }

--- a/packages/itmat-interface/config/config.sample.json
+++ b/packages/itmat-interface/config/config.sample.json
@@ -1,5 +1,5 @@
 {
-    "appName": "NAME",
+    "appName": "IDEA-FAST DMP",
     "database": {
         "mongo_url": "mongodb://localhost:27017",
         "database": "itmat",
@@ -20,7 +20,7 @@
     },
     "server": {
         "port": 3003
-    },
+    },    
     "bcrypt": {
         "saltround": 2
     },
@@ -34,5 +34,6 @@
     },
     "sessionsSecret": "Change_Me",
     "aesSecret": "change_this",
-    "nodemailer": {}
+    "nodemailer": {},
+    "adminEmail": "admin_wp5@ideafast.eu"
 }

--- a/packages/itmat-interface/src/graphql/schema.ts
+++ b/packages/itmat-interface/src/graphql/schema.ts
@@ -249,6 +249,7 @@ enum LOG_ACTION {
     LOGOUT
     REQUEST_USERNAME_OR_RESET_PASSWORD
     RESET_PASSWORD
+    REQUEST_EXPIRY_DATE
 
     # KEY
     REGISTER_PUBKEY
@@ -464,7 +465,7 @@ type Query {
 
 type Mutation {
     # USER
-    login(username: String!, password: String!, totp: String!): User
+    login(username: String!, password: String!, totp: String!, requestexpirydate: Boolean): User
     logout: GenericResponse
     requestUsernameOrResetPassword(
         forgotUsername: Boolean!,
@@ -474,6 +475,7 @@ type Mutation {
     ): GenericResponse
     resetPassword(encryptedEmail: String!, token: String!, newPassword: String!): GenericResponse
     createUser(user: CreateUserInput!): GenericResponse
+    requestExpiryDate(username: String, email: String): GenericResponse
     
     # PUBLIC KEY AUTHENTICATION
     registerPubkey(pubkey: String!, signature: String!, associatedUserId: String): Pubkey    

--- a/packages/itmat-interface/src/utils/configManager.ts
+++ b/packages/itmat-interface/src/utils/configManager.ts
@@ -12,6 +12,7 @@ export interface IConfiguration extends IServerConfig {
     nodemailer: any;
     aesSecret: string;
     sessionsSecret: string;
+    adminEmail: string;
 }
 
 class ConfigurationManager {

--- a/packages/itmat-interface/test/serverTests/users.test.ts
+++ b/packages/itmat-interface/test/serverTests/users.test.ts
@@ -694,7 +694,7 @@ describe('USERS API', () => {
             expect(res.status).toBe(200);
             expect(res.body.data.login).toBeNull();
             expect(res.body.errors).toHaveLength(1);
-            expect(res.body.errors[0].message).toBe('Account Expired.');
+            expect(res.body.errors[0].message).toBe('Account Expired. Please request a new expiry date!');
             await admin.post('/graphql').send(
                 {
                     query: print(DELETE_USER),

--- a/packages/itmat-ui-react/src/components/login/login.tsx
+++ b/packages/itmat-ui-react/src/components/login/login.tsx
@@ -5,6 +5,7 @@ import { LOGIN, WHO_AM_I } from 'itmat-commons';
 import { NavLink } from 'react-router-dom';
 import css from './login.module.css';
 import { Input, Form, Button, Alert } from 'antd';
+import Checkbox from 'antd/lib/checkbox/Checkbox';
 
 const gitInfo = GitInfo();
 
@@ -46,11 +47,27 @@ export const LoginBox: React.FunctionComponent = () => {
                                             <br />
                                         </>
                                     ) : null}
-                                    <Form.Item>
-                                        <Button type='primary' disabled={loading} loading={loading} htmlType='submit'>
-                                            Login
-                                        </Button>
-                                    </Form.Item>
+                                    {(error?.message === 'Account Expired. Please request a new expiry date!') ? (
+                                        <>
+                                            <Form.Item name='requestexpirydate' valuePropName='checked' hasFeedback rules={[{ required: true, message: ' ' }]}>
+                                                <Checkbox> Tick the box to request a new expiry date! </Checkbox>
+                                            </Form.Item>
+                                            <Form.Item>
+                                                <Button type='primary' disabled={loading} loading={loading} htmlType='submit'>
+                                                    Submit Request
+                                                </Button>
+                                            </Form.Item>
+                                        </>
+                                    ) :
+                                        <>
+                                            <Form.Item>
+                                                <Button type='primary' disabled={loading} loading={loading} htmlType='submit'>
+                                                    Login
+                                                </Button>
+                                            </Form.Item>
+                                        </>
+                                    }
+
                                 </Form>
                             </div>
                             <br />

--- a/packages/itmat-ui-react/src/components/profilemnt/profilemnt.tsx
+++ b/packages/itmat-ui-react/src/components/profilemnt/profilemnt.tsx
@@ -66,7 +66,7 @@ export const ProfileManagementSection: React.FunctionComponent = () => {
                                 }} /> Your account is close to expiring!
                                 <br />
                                 <br />
-                                <Button disabled={whoamiloading || requestExpiryDateSent} onClick={() => {
+                                <Button disabled={requestExpiryDateSent} onClick={() => {
                                     requestExpiryDate({
                                         variables: {
                                             username: user.username,

--- a/packages/itmat-ui-react/src/components/profilemnt/profilemnt.tsx
+++ b/packages/itmat-ui-react/src/components/profilemnt/profilemnt.tsx
@@ -17,11 +17,14 @@ const {
     REGISTER_PUBKEY,
     GET_PUBKEYS,
     ISSUE_ACCESS_TOKEN,
-    GET_ORGANISATIONS
+    GET_ORGANISATIONS,
+    REQUEST_EXPIRY_DATE
 } = GQLRequests;
 
 export const ProfileManagementSection: React.FunctionComponent = () => {
     const { loading: whoamiloading, error: whoamierror, data: whoamidata } = useQuery(WHO_AM_I);
+    const [requestExpiryDate] = useMutation(REQUEST_EXPIRY_DATE, { onCompleted: () => { setRequestExpiryDateSent(true); } });
+    const [requestExpiryDateSent, setRequestExpiryDateSent] = React.useState(false);
 
     if (whoamiloading) {
         return <>
@@ -60,12 +63,30 @@ export const ProfileManagementSection: React.FunctionComponent = () => {
                                 <WarningOutlined style={{
                                     color: '#ffaa33',
                                     fontSize: '1.5rem'
-                                }} /> Your account is close to expiring !
+                                }} /> Your account is close to expiring!
                                 <br />
+                                <br />
+                                <Button disabled={whoamiloading || requestExpiryDateSent} onClick={() => {
+                                    requestExpiryDate({
+                                        variables: {
+                                            username: user.username,
+                                            email: user.email
+                                        }
+                                    });
+                                }}>
+                                    Request new expiry date!
+                                </Button>
                                 <br />
                                 <br /></>
                         : null
                 }
+                {requestExpiryDateSent ? (
+                    <>
+                        <Alert type='success' message={'New expiry date has been requested! Please wait for ADMIN to approve.'} />
+                        <br />
+                    </>
+                ) : null}
+
                 <Subsection title='Account Information'>
                     <EditUserForm user={user} key={user.id} />
                     <br />


### PR DESCRIPTION
### New feature of request a new expiry date.

- [ ]: User once login her/his account and see the account will be expiring soon, she/he can request for a new expiry date from My Account section. WP5 Admin mailing list will get a notification email about the request. Admin needs to revise the request and approve/deny accordingly.
- [ ]: User whose account has been expired can request for a new expiry date from Login page. Note that the user must provide correct username/password/totp in order to submit the request. WP5 Admin mailing list will get a notification email about the request. Admin needs to revise the request and approve/deny accordingly.
- [ ]: Once the new expiry date is updated by one of the ADMINs, a notification email will be sent to the user.