### PR TITLE
Fix: analytical environment proxy

### DIFF
--- a/packages/itmat-interface/src/server/router.ts
+++ b/packages/itmat-interface/src/server/router.ts
@@ -159,7 +159,7 @@ export class Router {
                 res.cookie('ae_proxy', req.headers['host']);
                 const data = (req.user as IUser).username + ':token';
                 preq.setHeader('authorization', `Basic ${Buffer.from(data).toString('base64')}`);
-                if (req.method == 'POST' && req.body) {
+                if (req.body && Object.keys(req.body).length) {
                     const contentType = preq.getHeader('Content-Type');
                     preq.setHeader('origin', config.aeEndpoint);
                     const writeBody = (bodyData: string) => {


### PR DESCRIPTION
Saving and renaming issues of Jupyter Notebook reported by WP3.

Jupyter Notebook use PUT method for renaming and saving, so I should also add PUT method when modify the request body in http-proxy-middleware.