### PR TITLE
Updates for the itmat-interface

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,7 @@ const typescriptRules = {
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': ['error', { args: 'after-used', varsIgnorePattern: '^__unused' }],
     '@typescript-eslint/no-this-alias': 'off',
-    '@typescript-eslint/no-explicit-any': 'warn'
+    '@typescript-eslint/no-explicit-any': 'error'
 };
 
 module.exports = {

--- a/packages/itmat-commons/src/utils/database.ts
+++ b/packages/itmat-commons/src/utils/database.ts
@@ -24,7 +24,7 @@ export interface IDatabase<Conf, Coll> {
 export class Database<configType extends IDatabaseBaseConfig, C = { [name in keyof configType['collections']]: Collection }> implements IDatabase<configType, C> {
 
     get db(): Db {
-        return this.localClient!.db(this.config!.database);
+        return this.localClient.db(this.config.database);
     }
 
     get client(): MongoClient | undefined {
@@ -59,13 +59,13 @@ export class Database<configType extends IDatabaseBaseConfig, C = { [name in key
         try {
             if (this.localClient)
                 await this.localClient.close();
-        } catch (e: any) {
+        } catch (e) {
             Logger.error(new CustomError('Cannot close Mongo connection', e));
         }
     }
 
     private assignCollections(): void {
-        const collections: C = Object.entries(this.config!.collections).reduce((a: any, e: [string, string]) => {
+        const collections: C = Object.entries(this.config.collections).reduce((a, e: [string, string]) => {
             a[e[0]] = this.db.collection(e[1]);
             return a;
         }, {});
@@ -74,7 +74,7 @@ export class Database<configType extends IDatabaseBaseConfig, C = { [name in key
 
     private async checkAllCollectionsArePresent(): Promise<void> {
         const collectionList: string[] = (await this.db.listCollections({}).toArray()).map((el) => el.name);
-        for (const each of Object.values(this.config!.collections)) {
+        for (const each of Object.values(this.config.collections)) {
             if (!collectionList.includes(each)) {
                 throw new CustomError(`Collection ${each} does not exist.`);
             }

--- a/packages/itmat-commons/src/utils/objStore.ts
+++ b/packages/itmat-commons/src/utils/objStore.ts
@@ -17,7 +17,7 @@ export class ObjectStore {
 
     public async isConnected(): Promise<boolean> {
         try {
-            await this.client!.listBuckets();
+            await this.client.listBuckets();
             return true;
         } catch (e) {
             return false;
@@ -45,16 +45,16 @@ export class ObjectStore {
 
     public async uploadFile(fileStream: Readable, studyId: string, uri: string): Promise<string> {
         const lowercasestudyid = studyId.toLowerCase();
-        const bucketExists = await this.client!.bucketExists(lowercasestudyid);
+        const bucketExists = await this.client.bucketExists(lowercasestudyid);
 
         if (!bucketExists) {
-            await this.client!.makeBucket(lowercasestudyid, this.config?.bucketRegion ?? '');
+            await this.client.makeBucket(lowercasestudyid, this.config?.bucketRegion ?? '');
         }
 
         /* check if object already exists because if it does, minio supplant the old file without warning*/
         let fileExists;
         try {
-            await this.client!.statObject(lowercasestudyid, uri);
+            await this.client.statObject(lowercasestudyid, uri);
             fileExists = true;
         } catch (e) {
             fileExists = false;
@@ -64,14 +64,14 @@ export class ObjectStore {
             throw new Error(`File "${uri}" of study "${studyId}" already exists.`);
         }
 
-        const result = await this.client!.putObject(lowercasestudyid, uri, fileStream);
+        const result = await this.client.putObject(lowercasestudyid, uri, fileStream);
         return result.etag;
     }
 
     public async downloadFile(studyId: string, uri: string): Promise<Readable> {
         // PRECONDITION: studyId and file exists (checked by interface resolver)
         const lowercasestudyid = studyId.toLowerCase();
-        const stream = this.client!.getObject(lowercasestudyid, uri);
+        const stream = this.client.getObject(lowercasestudyid, uri);
         return stream as Promise<Readable>;
     }
 }

--- a/packages/itmat-commons/src/utils/poller.ts
+++ b/packages/itmat-commons/src/utils/poller.ts
@@ -7,18 +7,18 @@ export interface IJobPollerConfig {
     jobType?: string; // if undefined, matches all jobs
     jobCollection: mongodb.Collection<IJobEntry<any>>; // collection to poll
     pollingInterval: number; // in ms
-    action: (document: any) => void; // gets called every time there is new document
+    action: (document) => void; // gets called every time there is new document
 }
 
 export class JobPoller {
     private intervalObj?: NodeJS.Timeout;
-    private readonly matchObj: any;
+    private readonly matchObj;
 
     private readonly identity: string;
     private readonly jobType?: string;
     private readonly jobCollection: mongodb.Collection<IJobEntry<any>>;
     private readonly pollingInterval: number;
-    private readonly action: (document: any) => void;
+    private readonly action: (document) => void;
 
     constructor(config: IJobPollerConfig) {
         this.identity = config.identity;

--- a/packages/itmat-interface/src/authentication/pubkeyAuthentication.ts
+++ b/packages/itmat-interface/src/authentication/pubkeyAuthentication.ts
@@ -6,7 +6,7 @@ import { IUser } from '@itmat-broker/itmat-types';
 
 export async function userRetrieval(pubkey: string): Promise<IUser> {
     // retrieve userId associated with the token
-    const pubkeyrec = await db.collections!.pubkeys_collection.findOne({ jwtPubkey: pubkey, deleted: null });
+    const pubkeyrec = await db.collections.pubkeys_collection.findOne({ jwtPubkey: pubkey, deleted: null });
     if (pubkeyrec === null || pubkeyrec === undefined) {
         throw new GraphQLError('The public-key embedded in the JWT is not valid!', { extensions: { code: ApolloServerErrorCode.BAD_USER_INPUT } });
     }
@@ -14,7 +14,7 @@ export async function userRetrieval(pubkey: string): Promise<IUser> {
         throw new GraphQLError('The public-key embedded in the JWT is not associated with any user!', { extensions: { code: ApolloServerErrorCode.BAD_USER_INPUT } });
     }
 
-    const associatedUser: IUser | null = await db.collections!.users_collection.findOne({ deleted: null, id: pubkeyrec.associatedUserId }, { projection: { _id: 0 } });
+    const associatedUser: IUser | null = await db.collections.users_collection.findOne({ deleted: null, id: pubkeyrec.associatedUserId }, { projection: { _id: 0 } });
     if (!associatedUser) {
         throw new GraphQLError('The user assciated with the public-key embedded in the JWT is not existed or already deleted!', { extensions: { code: ApolloServerErrorCode.BAD_USER_INPUT } });
     }

--- a/packages/itmat-interface/src/database/database.ts
+++ b/packages/itmat-interface/src/database/database.ts
@@ -22,7 +22,7 @@ export interface IDatabaseConfig extends IDatabaseBaseConfig {
 
 export interface IDatabaseCollectionConfig {
     users_collection: Collection<IUser>,
-    jobs_collection: Collection<IJobEntry<any>>,
+    jobs_collection: Collection<IJobEntry<unknown>>,
     studies_collection: Collection<IStudy>,
     projects_collection: Collection<IProject>,
     queries_collection: Collection<IQueryEntry>,

--- a/packages/itmat-interface/src/emailer/emailer.ts
+++ b/packages/itmat-interface/src/emailer/emailer.ts
@@ -1,19 +1,12 @@
 import nodemailer from 'nodemailer';
+import * as SMTPTransport from 'nodemailer/lib/smtp-transport';
 import appConfig from '../utils/configManager';
-import { Attachment } from 'nodemailer/lib/mailer';
-
-export interface IMail {
-    from: string,
-    to: string,
-    subject: string,
-    html: string,
-    attachments?: Attachment[];
-}
+import { IMail } from '@itmat-broker/itmat-types';
 
 class Mailer {
     private readonly _client: nodemailer.Transporter;
 
-    constructor(config: any) {
+    constructor(config: SMTPTransport.Options) {
         this._client = nodemailer.createTransport(config);
     }
 

--- a/packages/itmat-interface/src/graphql/core/fieldCore.ts
+++ b/packages/itmat-interface/src/graphql/core/fieldCore.ts
@@ -1,17 +1,19 @@
 import { IFieldEntry, enumValueType, IUser } from '@itmat-broker/itmat-types';
 import { db } from '../../database/database';
 import { v4 as uuid } from 'uuid';
+import { MarkOptional } from 'ts-essentials';
+
 export class FieldCore {
     public async getFieldsOfStudy(studyId: string, detailed: boolean, getOnlyTheseFields?: string[]): Promise<IFieldEntry[]> {
         /* ASSUMING projectId and studyId match*/
         /* if detailed=false, only returns the fieldid in an array */
         /* constructing queryObj; if projectId is provided then only those in the approved fields are returned */
-        let queryObj: any = { studyId };
+        let queryObj = { studyId };
         if (getOnlyTheseFields) {  // if both study id and project id are provided then just make sure they belong to each other
             queryObj = { studyId, fieldId: { $in: getOnlyTheseFields } };
         }
 
-        const aggregatePipeline: any = [
+        const aggregatePipeline = [
             { $match: queryObj }
         ];
         /* if detailed=false, only returns the fieldid in an array */
@@ -19,17 +21,17 @@ export class FieldCore {
             aggregatePipeline.push({ $group: { _id: null, array: { $addToSet: '$fieldId' } } });
         }
 
-        const cursor = db.collections!.field_dictionary_collection.aggregate<IFieldEntry>(aggregatePipeline);
+        const cursor = db.collections.field_dictionary_collection.aggregate<IFieldEntry>(aggregatePipeline);
         return cursor.toArray();
     }
 
 }
 
 
-export function validateAndGenerateFieldEntry(fieldEntry: any, requester: IUser) {
+export function validateAndGenerateFieldEntry(fieldEntry: MarkOptional<IFieldEntry, 'id' | 'studyId' | 'dateAdded' | 'dateDeleted' | 'dataVersion' | 'possibleValues'>, requester: IUser) {
     // duplicates with existing fields are checked by caller function
     const error: string[] = [];
-    const complusoryField = [
+    const complusoryField: (keyof IFieldEntry)[] = [
         'fieldId',
         'fieldName',
         'dataType'
@@ -63,7 +65,7 @@ export function validateAndGenerateFieldEntry(fieldEntry: any, requester: IUser)
         }
     }
 
-    const newField: any = {
+    const newField: IFieldEntry = {
         fieldId: fieldEntry.fieldId,
         fieldName: fieldEntry.fieldName,
         tableName: fieldEntry.tableName,

--- a/packages/itmat-interface/src/graphql/core/jobCore.ts
+++ b/packages/itmat-interface/src/graphql/core/jobCore.ts
@@ -1,10 +1,16 @@
 import { IJobEntry } from '@itmat-broker/itmat-types';
 import { v4 as uuid } from 'uuid';
 import { db } from '../../database/database';
+import { GraphQLError } from 'graphql';
+import { errorCodes } from '../errors';
 
 export class JobCore {
-    public async createJob(userId: string, jobType: string, files: string[], studyId: string, projectId?: string, jobId?: string): Promise<IJobEntry<any>> {
-        const job: IJobEntry<any> = {
+    public async createJob(userId: string, jobType: string, files: string[], studyId: string, projectId?: string, jobId?: string): Promise<IJobEntry<unknown>> {
+        // check database collections existence
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
+        const job: IJobEntry<unknown> = {
             requester: userId,
             id: jobId || uuid(),
             studyId,
@@ -16,7 +22,7 @@ export class JobCore {
             error: null,
             cancelled: false
         };
-        await db.collections!.jobs_collection.insertOne(job);
+        await db.collections.jobs_collection.insertOne(job);
         return job;
     }
 }

--- a/packages/itmat-interface/src/graphql/core/permissionCore.ts
+++ b/packages/itmat-interface/src/graphql/core/permissionCore.ts
@@ -14,10 +14,16 @@ interface ICreateRoleInput {
 
 export class PermissionCore {
     public async getAllRolesOfStudyOrProject(studyId: string, projectId?: string): Promise<IRole[]> {
-        return db.collections!.roles_collection.find({ studyId, projectId }).toArray();
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
+        return db.collections.roles_collection.find({ studyId, projectId }).toArray();
     }
 
     public async userHasTheNeccessaryManagementPermission(type: string, operation: string, user: IUser, studyId: string, projectId?: string): Promise<boolean> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         if (user === undefined) {
             return false;
         }
@@ -27,7 +33,7 @@ export class PermissionCore {
             return true;
         }
         const tag = `permissions.manage.${type}`;
-        const roles = await db.collections!.roles_collection.aggregate([
+        const roles = await db.collections.roles_collection.aggregate([
             { $match: { studyId, projectId: { $in: [projectId, null] }, users: user.id, deleted: null } }, // matches all the role documents where the study and project matches and has the user inside
             { $match: { [tag]: operation } }
         ]).toArray();
@@ -38,6 +44,9 @@ export class PermissionCore {
     }
 
     public async combineUserDataPermissions(operation: string, user: IUser, studyId: string, projectId?: string): Promise<Record<string, string[]> | false> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         if (user.type === userTypes.ADMIN) {
             const matchAnyString = '^.*$';
             return {
@@ -46,7 +55,7 @@ export class PermissionCore {
                 fieldIds: [matchAnyString]
             };
         }
-        const roles = await db.collections!.roles_collection.aggregate([
+        const roles = await db.collections.roles_collection.aggregate([
             { $match: { studyId, projectId: { $in: [projectId, null] }, users: user.id, deleted: null } }, // matches all the role documents where the study and project matches and has the user inside
             { $match: { 'permissions.data.operations': operation } }
         ]).toArray();
@@ -82,6 +91,9 @@ export class PermissionCore {
     }
 
     public async userHasTheNeccessaryDataPermission(operation: string, user: IUser, studyId: string, projectId?: string): Promise<Record<string, any> | false> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         if (user === undefined) {
             return false;
         }
@@ -101,7 +113,7 @@ export class PermissionCore {
             };
         }
 
-        const roles = await db.collections!.roles_collection.aggregate([
+        const roles = await db.collections.roles_collection.aggregate([
             { $match: { studyId, projectId: { $in: [projectId, null] }, users: user.id, deleted: null } }, // matches all the role documents where the study and project matches and has the user inside
             { $match: { 'permissions.data.operations': operation } }
         ]).toArray();
@@ -143,7 +155,7 @@ export class PermissionCore {
         return { matchObj: roleObj, hasVersioned: hasVersioned, uploaders: uploaders, raw: raw, roleraw: roleraw };
     }
 
-    public combineMultiplePermissions(permissions: any[]): any {
+    public combineMultiplePermissions(permissions: any[]) {
         const res = {
             matchObj: [],
             hasVersioned: false,
@@ -167,7 +179,10 @@ export class PermissionCore {
     }
 
     public async removeRole(roleId: string): Promise<void> {
-        const updateResult = await db.collections!.roles_collection.findOneAndUpdate({ id: roleId, deleted: null }, { $set: { deleted: new Date().valueOf() } });
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
+        const updateResult = await db.collections.roles_collection.findOneAndUpdate({ id: roleId, deleted: null }, { $set: { deleted: new Date().valueOf() } });
         if (updateResult) {
             return;
         } else {
@@ -176,6 +191,9 @@ export class PermissionCore {
     }
 
     public async removeRoleFromStudyOrProject({ studyId, projectId }: { studyId: string, projectId?: string } | { studyId?: string, projectId: string }): Promise<void> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         if (studyId === undefined && projectId === undefined) {
             throw new GraphQLError('Neither studyId nor projectId is provided');
         }
@@ -187,7 +205,7 @@ export class PermissionCore {
         } else if (projectId !== undefined) {
             queryObj = { projectId, deleted: null };
         }
-        const updateResult = await db.collections!.roles_collection.updateMany(queryObj, { $set: { deleted: new Date().valueOf() } });
+        const updateResult = await db.collections.roles_collection.updateMany(queryObj, { $set: { deleted: new Date().valueOf() } });
         if (updateResult.acknowledged) {
             return;
         } else {
@@ -196,6 +214,9 @@ export class PermissionCore {
     }
 
     public async editRoleFromStudyOrProject(roleId: string, name?: string, description?: string, permissionChanges?: any, userChanges?: { add: string[], remove: string[] }): Promise<IRole> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         if (permissionChanges === undefined) {
             permissionChanges = {
                 data: { subjectIds: [], visitIds: [], fieldIds: [], uploaders: ['^.*$'], hasVersioned: false, operations: [] },
@@ -210,7 +231,7 @@ export class PermissionCore {
         }
         if (userChanges === undefined) { userChanges = { add: [], remove: [] }; }
 
-        const bulkop = db.collections!.roles_collection.initializeUnorderedBulkOp();
+        const bulkop = db.collections.roles_collection.initializeUnorderedBulkOp();
         bulkop.find({ id: roleId, deleted: null }).updateOne({ $set: { permissions: permissionChanges }, $addToSet: { users: { $each: userChanges.add } } });
         bulkop.find({ id: roleId, deleted: null }).updateOne({ $set: { permissions: permissionChanges }, $pullAll: { users: userChanges.remove } });
         if (name) {
@@ -220,7 +241,7 @@ export class PermissionCore {
             bulkop.find({ id: roleId, deleted: null }).updateOne({ $set: { description } });
         }
         const result: BulkWriteResult = await bulkop.execute();
-        const resultingRole = await db.collections!.roles_collection.findOne({ id: roleId, deleted: null });
+        const resultingRole = await db.collections.roles_collection.findOne({ id: roleId, deleted: null });
         if (!resultingRole) {
             throw new GraphQLError('Role does not exist', { extensions: { code: errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY } });
         }
@@ -230,8 +251,8 @@ export class PermissionCore {
         let validSubjects: Array<string | RegExp> = [];
         if (permissionChanges.data?.filters) {
             if (permissionChanges.data.filters.length > 0) {
-                const subqueries = translateCohort(permissionChanges.data.filters);
-                validSubjects = (await db.collections!.data_collection.aggregate([{
+                const subqueries: any[] = translateCohort(permissionChanges.data.filters);
+                validSubjects = (await db.collections.data_collection.aggregate([{
                     $match: { $and: subqueries }
                 }]).toArray()).map(el => el.m_subjectId);
             }
@@ -239,7 +260,7 @@ export class PermissionCore {
 
 
         // update the data and field records
-        const dataBulkOp = db.collections!.data_collection.initializeUnorderedBulkOp();
+        const dataBulkOp = db.collections.data_collection.initializeUnorderedBulkOp();
         const filters: Record<string, string[]> = {
             subjectIds: permissionChanges.data?.subjectIds || [],
             visitIds: permissionChanges.data?.visitIds || [],
@@ -274,7 +295,7 @@ export class PermissionCore {
         }).update({
             $set: { [dataTag]: false }
         });
-        const fieldBulkOp = db.collections!.field_dictionary_collection.initializeUnorderedBulkOp();
+        const fieldBulkOp = db.collections.field_dictionary_collection.initializeUnorderedBulkOp();
         const fieldIds = permissionChanges.data?.fieldIds || [];
         const fieldTag = `metadata.${'role:'.concat(roleId)}`;
         fieldBulkOp.find({
@@ -301,6 +322,9 @@ export class PermissionCore {
     }
 
     public async addRole(opt: ICreateRoleInput): Promise<IRole> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         /* add user role */
         const role: IRole = {
             id: uuid(),
@@ -330,7 +354,7 @@ export class PermissionCore {
             metadata: {},
             deleted: null
         };
-        const updateResult = await db.collections!.roles_collection.insertOne(role);
+        const updateResult = await db.collections.roles_collection.insertOne(role);
         if (updateResult.acknowledged) {
             return role;
         } else {
@@ -389,13 +413,13 @@ export function translateCohort(cohort: any) {
                 const countOperation = select.value.split(' ');
                 const countfield = select.field + '.count';
                 if (countOperation[0] === '=') {
-                    (match as any)[countfield] = { $eq: parseInt(countOperation[1], 10) };
+                    match[countfield] = { $eq: parseInt(countOperation[1], 10) };
                 }
                 if (countOperation[0] === '>') {
-                    (match as any)[countfield] = { $gt: parseInt(countOperation[1], 10) };
+                    match[countfield] = { $gt: parseInt(countOperation[1], 10) };
                 }
                 if (countOperation[0] === '<') {
-                    (match as any)[countfield] = { $lt: parseInt(countOperation[1], 10) };
+                    match[countfield] = { $lt: parseInt(countOperation[1], 10) };
                 }
                 break;
             }

--- a/packages/itmat-interface/src/graphql/core/queryCore.ts
+++ b/packages/itmat-interface/src/graphql/core/queryCore.ts
@@ -1,9 +1,26 @@
-import { IQueryEntry } from '@itmat-broker/itmat-types';
+import { IQueryEntry, ICohortSelection, INewFieldSelection } from '@itmat-broker/itmat-types';
 import { v4 as uuid } from 'uuid';
 import { db } from '../../database/database';
+import { GraphQLError } from 'graphql';
+import { errorCodes } from '../errors';
+
+export interface QueryObjInput {
+    userId: string;
+    queryString: {
+        data_requested: string[];
+        cohort: ICohortSelection[][];
+        new_fields: INewFieldSelection[];
+        format: string;
+    };
+    studyId: string;
+    projectId?: string;
+}
 
 export class QueryCore {
-    public async createQuery(args: any): Promise<IQueryEntry> {
+    public async createQuery(args: { query: QueryObjInput }): Promise<IQueryEntry> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         const query: IQueryEntry = {
             requester: args.query.userId,
             id: uuid(),
@@ -17,14 +34,17 @@ export class QueryCore {
             cohort: args.query.queryString.cohort,
             new_fields: args.query.queryString.new_fields
         };
-        await db.collections!.queries_collection.insertOne(query);
+        await db.collections.queries_collection.insertOne(query);
         return query;
     }
 
     public async getUsersQuery_NoResult(userId: string): Promise<IQueryEntry[]> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         //@ts-ignore
-        return db.collections!.queries_collection.find<IQueryEntry>({ requester: userId }, { projection: { _id: 0, claimedBy: 0, queryResult: 0 } }).toArray();
+        return db.collections.queries_collection.find<IQueryEntry>({ requester: userId }, { projection: { _id: 0, claimedBy: 0, queryResult: 0 } }).toArray();
     }
 
 }

--- a/packages/itmat-interface/src/graphql/core/studyCore.ts
+++ b/packages/itmat-interface/src/graphql/core/studyCore.ts
@@ -15,7 +15,10 @@ export class StudyCore {
     constructor(private readonly localPermissionCore: PermissionCore) { }
 
     public async findOneStudy_throwErrorIfNotExist(studyId: string): Promise<IStudy> {
-        const studySearchResult = await db.collections!.studies_collection.findOne({ id: studyId, deleted: null })!;
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
+        const studySearchResult = await db.collections.studies_collection.findOne({ id: studyId, deleted: null })!;
         if (studySearchResult === null || studySearchResult === undefined) {
             throw new GraphQLError('Study does not exist.', { extensions: { code: errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY } });
         }
@@ -23,7 +26,10 @@ export class StudyCore {
     }
 
     public async findOneProject_throwErrorIfNotExist(projectId: string): Promise<IProject> {
-        const projectSearchResult = await db.collections!.projects_collection.findOne({ id: projectId, deleted: null })!;
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
+        const projectSearchResult = await db.collections.projects_collection.findOne({ id: projectId, deleted: null })!;
         if (projectSearchResult === null || projectSearchResult === undefined) {
             throw new GraphQLError('Project does not exist.', { extensions: { code: errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY } });
         }
@@ -31,8 +37,11 @@ export class StudyCore {
     }
 
     public async createNewStudy(studyName: string, description: string, type: studyType, requestedBy: string): Promise<IStudy> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         /* check if study already  exist (lowercase because S3 minio buckets cant be mixed case) */
-        const existingStudies = await db.collections!.studies_collection.aggregate(
+        const existingStudies = await db.collections.studies_collection.aggregate(
             [
                 { $match: { deleted: null } },
                 {
@@ -64,12 +73,15 @@ export class StudyCore {
             ontologyTrees: [],
             metadata: {}
         };
-        await db.collections!.studies_collection.insertOne(study);
+        await db.collections.studies_collection.insertOne(study);
         return study;
     }
 
     public async editStudy(studyId: string, description: string): Promise<IStudy> {
-        const res = await db.collections!.studies_collection.findOneAndUpdate({ id: studyId }, { $set: { description: description } }, { returnDocument: 'after' });
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
+        const res = await db.collections.studies_collection.findOneAndUpdate({ id: studyId }, { $set: { description: description } }, { returnDocument: 'after' });
         if (res) {
             return res;
         } else {
@@ -78,11 +90,14 @@ export class StudyCore {
     }
 
     public async createNewDataVersion(studyId: string, tag: string, dataVersion: string): Promise<IStudyDataVersion | null> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         const newDataVersionId = uuid();
         const newContentId = uuid();
 
         // update data
-        const resData = await db.collections!.data_collection.updateMany({
+        const resData = await db.collections.data_collection.updateMany({
             m_studyId: studyId,
             m_versionId: null
         }, {
@@ -91,7 +106,7 @@ export class StudyCore {
             }
         });
         // update field
-        const resField = await db.collections!.field_dictionary_collection.updateMany({
+        const resField = await db.collections.field_dictionary_collection.updateMany({
             studyId: studyId,
             dataVersion: null
         }, {
@@ -100,7 +115,7 @@ export class StudyCore {
             }
         });
         // update standardization
-        const resStandardization = await db.collections!.standardizations_collection.updateMany({
+        const resStandardization = await db.collections.standardizations_collection.updateMany({
             studyId: studyId,
             dataVersion: null
         }, {
@@ -110,7 +125,7 @@ export class StudyCore {
         });
 
         // update ontology trees
-        const resOntologyTrees = await db.collections!.studies_collection.updateOne({ 'id': studyId, 'deleted': null, 'ontologyTrees.dataVersion': null }, {
+        const resOntologyTrees = await db.collections.studies_collection.updateOne({ 'id': studyId, 'deleted': null, 'ontologyTrees.dataVersion': null }, {
             $set: {
                 'ontologyTrees.$.dataVersion': newDataVersionId
             }
@@ -123,7 +138,7 @@ export class StudyCore {
 
 
         // update permissions based on roles
-        const roles = await db.collections!.roles_collection.find<IRole>({ studyId: studyId, deleted: null }).toArray();
+        const roles = await db.collections.roles_collection.find<IRole>({ studyId: studyId, deleted: null }).toArray();
         for (const role of roles) {
             const filters: Record<string, string[]> = {
                 subjectIds: role.permissions.data?.subjectIds || [],
@@ -135,8 +150,8 @@ export class StudyCore {
             if (role.permissions.data?.filters) {
                 if (role.permissions.data.filters.length > 0) {
                     validSubjects = [];
-                    const subqueries = translateCohort(role.permissions.data.filters);
-                    validSubjects = (await db.collections!.data_collection.aggregate([{
+                    const subqueries: any[] = translateCohort(role.permissions.data.filters);
+                    validSubjects = (await db.collections.data_collection.aggregate([{
                         $match: { $and: subqueries }
                     }]).toArray()).map(el => el.m_subjectId);
                 }
@@ -145,7 +160,7 @@ export class StudyCore {
                 validSubjects = [/^.*$/];
             }
             const tag = `metadata.${'role:'.concat(role.id)}`;
-            await db.collections!.data_collection.updateMany({
+            await db.collections.data_collection.updateMany({
                 m_studyId: studyId,
                 m_versionId: newDataVersionId,
                 $and: [
@@ -157,7 +172,7 @@ export class StudyCore {
             }, {
                 $set: { [tag]: true }
             });
-            await db.collections!.data_collection.updateMany({
+            await db.collections.data_collection.updateMany({
                 m_studyId: studyId,
                 m_versionId: newDataVersionId,
                 $or: [
@@ -169,19 +184,19 @@ export class StudyCore {
             }, {
                 $set: { [tag]: false }
             });
-            await db.collections!.field_dictionary_collection.updateMany({
+            await db.collections.field_dictionary_collection.updateMany({
                 studyId: studyId,
                 dataVersion: newDataVersionId,
                 fieldId: { $in: filters.fieldIds.map((el: string) => new RegExp(el)) }
             }, {
-                $set: { [tag as any]: true }
+                $set: { [tag]: true }
             });
-            await db.collections!.field_dictionary_collection.updateMany({
+            await db.collections.field_dictionary_collection.updateMany({
                 studyId: studyId,
                 dataVersion: newDataVersionId,
                 fieldId: { $nin: filters.fieldIds.map((el: string) => new RegExp(el)) }
             }, {
-                $set: { [tag as any]: false }
+                $set: { [tag]: false }
             });
         }
 
@@ -193,7 +208,7 @@ export class StudyCore {
             tag: tag,
             updateDate: (new Date().valueOf()).toString()
         };
-        await db.collections!.studies_collection.updateOne({ id: studyId }, {
+        await db.collections.studies_collection.updateOne({ id: studyId }, {
             $push: { dataVersions: newDataVersion },
             $inc: {
                 currentDataVersion: 1
@@ -202,9 +217,12 @@ export class StudyCore {
         return newDataVersion;
     }
 
-    public async uploadOneDataClip(studyId: string, permissions: any, fieldList: Partial<IFieldEntry>[], data: IDataClip[], requester: IUser): Promise<any> {
+    public async uploadOneDataClip(studyId: string, permissions, fieldList: Partial<IFieldEntry>[], data: IDataClip[], requester: IUser): Promise<any> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         const response: IGenericResponse[] = [];
-        let bulk = db.collections!.data_collection.initializeUnorderedBulkOp();
+        let bulk = db.collections.data_collection.initializeUnorderedBulkOp();
         // remove duplicates by subjectId, visitId and fieldId
         const keysToCheck: Array<keyof IDataClip> = ['visitId', 'subjectId', 'fieldId'];
         const filteredData = data.filter(
@@ -317,7 +335,7 @@ export class StudyCore {
                             error = `Field ${dataClip.fieldId}: Cannot parse as categorical, possible values not defined.`;
                             break;
                         }
-                        if (!fieldInDb.possibleValues.map((el: any) => el.code).includes(dataClip.value?.toString())) {
+                        if (!fieldInDb.possibleValues.map((el) => el.code).includes(dataClip.value?.toString())) {
                             error = `Field ${dataClip.fieldId}: Cannot parse as categorical, value not in value list.`;
                             break;
                         } else {
@@ -347,9 +365,9 @@ export class StudyCore {
             let objWithData: Partial<MatchKeysAndValues<IDataEntry>>;
             // update the file data differently
             if (fieldInDb.dataType === 'file') {
-                const existing = await db.collections!.data_collection.findOne(obj);
+                const existing = await db.collections.data_collection.findOne(obj);
                 if (!existing) {
-                    await db.collections!.data_collection.insertOne({
+                    await db.collections.data_collection.insertOne({
                         ...obj,
                         id: uuid(),
                         uploadedAt: (new Date()).valueOf(),
@@ -369,7 +387,7 @@ export class StudyCore {
                     metadata: {
                         ...dataClip.metadata,
                         participantId: dataClip.subjectId,
-                        add: ((existing?.metadata as any)?.add || []).concat(parsedValue),
+                        add: (existing?.metadata?.add || []).concat(parsedValue),
                         uploader: requester.id
                     },
                     uploadedBy: requester.id
@@ -391,7 +409,7 @@ export class StudyCore {
             }
             if (bulk.batches.length > 999) {
                 await bulk.execute();
-                bulk = db.collections!.data_collection.initializeUnorderedBulkOp();
+                bulk = db.collections.data_collection.initializeUnorderedBulkOp();
             }
         }
         bulk.batches.length !== 0 && await bulk.execute();
@@ -403,11 +421,11 @@ export class StudyCore {
         if (!data.file || typeof (data.file) === 'string') {
             return { code: errorCodes.CLIENT_MALFORMED_INPUT, description: 'Invalid File Stream' };
         }
-        const study = await db.collections!.studies_collection.findOne({ id: studyId });
+        const study = await db.collections.studies_collection.findOne({ id: studyId });
         if (!study) {
             return { code: errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY, description: 'Study does not exist.' };
         }
-        const sitesIDMarkers = (await db.collections!.organisations_collection.find<IOrganisation>({ deleted: null }).toArray()).reduce<any>((acc, curr) => {
+        const sitesIDMarkers = (await db.collections.organisations_collection.find<IOrganisation>({ deleted: null }).toArray()).reduce<any>((acc, curr) => {
             if (curr.metadata?.siteIDMarker) {
                 acc[curr.metadata.siteIDMarker] = curr.shortname;
             }
@@ -447,7 +465,7 @@ export class StudyCore {
         const file: FileUpload = await data.file;
 
         // check if old files exist; if so, denote it as deleted
-        const dataEntry = await db.collections!.data_collection.findOne({ m_studyId: studyId, m_visitId: data.visitId, m_subjectId: data.subjectId, m_versionId: null, m_fieldId: data.fieldId });
+        const dataEntry = await db.collections.data_collection.findOne({ m_studyId: studyId, m_visitId: data.visitId, m_subjectId: data.subjectId, m_versionId: null, m_fieldId: data.fieldId });
         const oldFileId = dataEntry ? dataEntry.value : null;
         return new Promise<IFile>((resolve, reject) => {
 
@@ -511,10 +529,10 @@ export class StudyCore {
                     fileEntry.fileSize = readBytes.toString();
                     fileEntry.uri = fileUri;
                     fileEntry.hash = hashString;
-                    const insertResult = await db.collections!.files_collection.insertOne(fileEntry as IFile);
+                    const insertResult = await db.collections.files_collection.insertOne(fileEntry as IFile);
                     if (insertResult.acknowledged) {
                         // delete old file if existing
-                        await db.collections!.files_collection.findOneAndUpdate({ studyId: studyId, id: oldFileId }, { $set: { deleted: Date.now().valueOf() } });
+                        await db.collections.files_collection.findOneAndUpdate({ studyId: studyId, id: oldFileId }, { $set: { deleted: Date.now().valueOf() } });
                         resolve(fileEntry as IFile);
                     } else {
                         throw new GraphQLError(errorCodes.DATABASE_ERROR);
@@ -540,7 +558,7 @@ export class StudyCore {
             metadata: {}
         };
 
-        const getListOfPatientsResult = await db.collections!.data_collection.aggregate([
+        const getListOfPatientsResult = await db.collections.data_collection.aggregate([
             { $match: { m_studyId: studyId } },
             { $group: { _id: null, array: { $addToSet: '$m_subjectId' } } },
             { $project: { array: 1 } }
@@ -554,29 +572,32 @@ export class StudyCore {
             project.patientMapping = this.createPatientIdMapping(getListOfPatientsResult[0].array);
         }
 
-        await db.collections!.projects_collection.insertOne(project);
+        await db.collections.projects_collection.insertOne(project);
         return project;
     }
 
     public async deleteStudy(studyId: string): Promise<void> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         /* PRECONDITION: CHECKED THAT STUDY INDEED EXISTS */
-        const session = db.client!.startSession();
+        const session = db.client.startSession();
         session.startTransaction();
 
         const timestamp = new Date().valueOf();
 
         try {
             /* delete the study */
-            await db.collections!.studies_collection.findOneAndUpdate({ id: studyId, deleted: null }, { $set: { lastModified: timestamp, deleted: timestamp } });
+            await db.collections.studies_collection.findOneAndUpdate({ id: studyId, deleted: null }, { $set: { lastModified: timestamp, deleted: timestamp } });
 
             /* delete all projects related to the study */
-            await db.collections!.projects_collection.updateMany({ studyId, deleted: null }, { $set: { lastModified: timestamp, deleted: timestamp } });
+            await db.collections.projects_collection.updateMany({ studyId, deleted: null }, { $set: { lastModified: timestamp, deleted: timestamp } });
 
             /* delete all roles related to the study */
             await this.localPermissionCore.removeRoleFromStudyOrProject({ studyId });
 
             /* delete all files belong to the study*/
-            await db.collections!.files_collection.updateMany({ studyId, deleted: null }, { $set: { deleted: timestamp } });
+            await db.collections.files_collection.updateMany({ studyId, deleted: null }, { $set: { deleted: timestamp } });
 
             await session.commitTransaction();
             session.endSession();
@@ -591,10 +612,13 @@ export class StudyCore {
     }
 
     public async deleteProject(projectId: string): Promise<void> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         const timestamp = new Date().valueOf();
 
         /* delete all projects related to the study */
-        await db.collections!.projects_collection.findOneAndUpdate({ id: projectId, deleted: null }, { $set: { lastModified: timestamp, deleted: timestamp } }, { returnDocument: 'after' });
+        await db.collections.projects_collection.findOneAndUpdate({ id: projectId, deleted: null }, { $set: { lastModified: timestamp, deleted: timestamp } }, { returnDocument: 'after' });
 
         /* delete all roles related to the study */
         await this.localPermissionCore.removeRoleFromStudyOrProject({ projectId });

--- a/packages/itmat-interface/src/graphql/core/userCore.ts
+++ b/packages/itmat-interface/src/graphql/core/userCore.ts
@@ -9,14 +9,17 @@ import { MarkOptional } from 'ts-essentials';
 
 export class UserCore {
     public async getOneUser_throwErrorIfNotExists(username: string): Promise<IUser> {
-        const user = await db.collections!.users_collection.findOne({ deleted: null, username });
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
+        const user = await db.collections.users_collection.findOne({ deleted: null, username });
         if (user === undefined || user === null) {
             throw new GraphQLError('User does not exist.', { extensions: { code: errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY } });
         }
         return user;
     }
 
-    public async createUser(user: { password: string, otpSecret: string, username: string, organisation: string, type: userTypes, description: string, firstname: string, lastname: string, email: string, emailNotificationsActivated: boolean, metadata: any }): Promise<IUserWithoutToken> {
+    public async createUser(user: { password: string, otpSecret: string, username: string, organisation: string, type: userTypes, description: string, firstname: string, lastname: string, email: string, emailNotificationsActivated: boolean, metadata }): Promise<IUserWithoutToken> {
         const { password, otpSecret, organisation, username, type, description, firstname, lastname, email, emailNotificationsActivated, metadata } = user;
         const hashedPassword: string = await bcrypt.hash(password, config.bcrypt.saltround);
         const createdAt = Date.now();
@@ -41,7 +44,7 @@ export class UserCore {
             deleted: null
         };
 
-        const result = await db.collections!.users_collection.insertOne(entry);
+        const result = await db.collections.users_collection.insertOne(entry);
         if (result.acknowledged) {
             const cleared: MarkOptional<IUser, 'password' | 'otpSecret'> = { ...entry };
             delete cleared['password'];
@@ -53,14 +56,17 @@ export class UserCore {
     }
 
     public async deleteUser(userId: string): Promise<void> {
-        const session = db.client!.startSession();
+        if (!db.collections || !db.client) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
+        const session = db.client.startSession();
         session.startTransaction();
         try {
             /* delete the user */
-            await db.collections!.users_collection.findOneAndUpdate({ id: userId, deleted: null }, { $set: { deleted: new Date().valueOf(), password: 'DeletedUserDummyPassword' } }, { returnDocument: 'after', projection: { deleted: 1 } });
+            await db.collections.users_collection.findOneAndUpdate({ id: userId, deleted: null }, { $set: { deleted: new Date().valueOf(), password: 'DeletedUserDummyPassword' } }, { returnDocument: 'after', projection: { deleted: 1 } });
 
             /* delete all user records in roles related to the study */
-            await db.collections!.roles_collection.updateMany(
+            await db.collections.roles_collection.updateMany(
                 {
                     deleted: null,
                     users: userId
@@ -81,7 +87,10 @@ export class UserCore {
         }
     }
 
-    public async createOrganisation(org: { name: string, shortname: string | null, containOrg: string | null, metadata: any }): Promise<IOrganisation> {
+    public async createOrganisation(org: { name: string, shortname: string | null, containOrg: string | null, metadata }): Promise<IOrganisation> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         const { name, shortname, containOrg, metadata } = org;
         const entry: IOrganisation = {
             id: uuid(),
@@ -93,7 +102,7 @@ export class UserCore {
                 siteIDMarker: metadata.siteIDMarker
             } : {}
         };
-        const result = await db.collections!.organisations_collection.findOneAndUpdate({ name: name, deleted: null }, {
+        const result = await db.collections.organisations_collection.findOneAndUpdate({ name: name, deleted: null }, {
             $set: entry
         }, {
             upsert: true
@@ -106,6 +115,9 @@ export class UserCore {
     }
 
     public async registerPubkey(pubkeyobj: { pubkey: string, associatedUserId: string | null, jwtPubkey: string, jwtSeckey: string }): Promise<IPubkey> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         const { pubkey, associatedUserId, jwtPubkey, jwtSeckey } = pubkeyobj;
         const entry: IPubkey = {
             id: uuid(),
@@ -117,7 +129,7 @@ export class UserCore {
             deleted: null
         };
 
-        const result = await db.collections!.pubkeys_collection.insertOne(entry);
+        const result = await db.collections.pubkeys_collection.insertOne(entry);
         if (result.acknowledged) {
             return entry;
         } else {

--- a/packages/itmat-interface/src/graphql/resolvers/fileResolvers.ts
+++ b/packages/itmat-interface/src/graphql/resolvers/fileResolvers.ts
@@ -221,7 +221,7 @@ export const fileResolvers = {
                                     'uploader:user': requester.id,
                                     'add': [fileEntry.id],
                                     'remove': []
-                                }
+                                } as any
                             });
                         }
                         const insertResult = await db.collections!.files_collection.insertOne(fileEntry as IFile);
@@ -282,7 +282,7 @@ export const fileResolvers = {
                     metadata: {
                         add: [],
                         remove: []
-                    }
+                    } as any
                 });
             }
             const objWithData: Partial<MatchKeysAndValues<IDataEntry>> = {
@@ -292,9 +292,9 @@ export const fileResolvers = {
                 uploadedAt: (new Date()).valueOf(),
                 metadata: {
                     'uploader:user': requester.id,
-                    'add': existing?.metadata?.add ?? [],
+                    'add': (existing?.metadata as any)?.add ?? [],
                     'remove': ((existing?.metadata as any)?.remove || []).concat(args.fileId)
-                }
+                } as any
             };
             const updateResult = await db.collections!.data_collection.updateOne(obj, { $set: objWithData }, { upsert: true });
 

--- a/packages/itmat-interface/src/graphql/resolvers/index.ts
+++ b/packages/itmat-interface/src/graphql/resolvers/index.ts
@@ -27,18 +27,18 @@ const modules = [
 ];
 
 // const loggingDecorator = (reducerFunction: Function) => {
-//     return async (parent: any, args: any, context: any, info: any) => {
+//     return async (parent, args, context, info) => {
 //         return await reducerFunction(parent, args, context, info);
 //     };
 // };
 
-const bounceNotLoggedInDecorator = (reducerFunction: any) => {
-    return async (parent: any, args: any, context: any, info: any) => {
+const bounceNotLoggedInDecorator = (reducerFunction) => {
+    return async (parent, args, context, info) => {
         const uncheckedFunctionWhitelist = ['login', 'rsaSigner', 'keyPairGenwSignature', 'issueAccessToken', 'whoAmI', 'getOrganisations', 'requestUsernameOrResetPassword', 'resetPassword', 'createUser', 'writeLog', 'validateResetPassword'];
         const requester: IUser = context.req.user;
 
         if (!requester) {
-            if (!(uncheckedFunctionWhitelist as any).includes(reducerFunction.name)) {
+            if (!uncheckedFunctionWhitelist.includes(reducerFunction.name)) {
                 throw new GraphQLError(errorCodes.NOT_LOGGED_IN);
             }
         }
@@ -47,18 +47,18 @@ const bounceNotLoggedInDecorator = (reducerFunction: any) => {
 };
 
 
-const reduceInit: any = { JSON: GraphQLJSON };
+const reduceInit = { JSON: GraphQLJSON };
 export const resolvers = modules.reduce((a, e) => {
     const types = Object.keys(e);
     for (const each of types) {  // types can be Subscription | Query | Mutation | {{TYPE}}
         if (a[each] === undefined) {  // if a doesnt have types then create a empty obj
             a[each] = {};
         }
-        for (const funcName of Object.keys((e as any)[each])) {
+        for (const funcName of Object.keys(e[each])) {
             if (each === 'Subscription') {
-                (a as any)[each][funcName] = (e as any)[each][funcName];
+                a[each][funcName] = e[each][funcName];
             } else {
-                (a as any)[each][funcName] = bounceNotLoggedInDecorator((e as any)[each][funcName]);
+                a[each][funcName] = bounceNotLoggedInDecorator(e[each][funcName]);
             }
         }
     }

--- a/packages/itmat-interface/src/graphql/resolvers/jobResolvers.ts
+++ b/packages/itmat-interface/src/graphql/resolvers/jobResolvers.ts
@@ -20,6 +20,9 @@ export const jobResolvers = {
     Query: {},
     Mutation: {
         createDataCurationJob: async (__unused__parent: Record<string, unknown>, args: { file: string[], studyId: string }, context: any): Promise<IJobEntryForDataCuration[]> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
 
             /* check permission */
@@ -40,7 +43,7 @@ export const jobResolvers = {
             const jobList: IJobEntryForDataCuration[] = [];
             for (const oneFile of args.file) {
                 /* check if the file exists */
-                const file = await db.collections!.files_collection.findOne({ deleted: null, id: oneFile });
+                const file = await db.collections.files_collection.findOne({ deleted: null, id: oneFile });
                 if (!file) {
                     throw new GraphQLError(errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY);
                 }
@@ -67,7 +70,7 @@ export const jobResolvers = {
                     cancelled: false
                 };
 
-                const result = await db.collections!.jobs_collection.insertOne(job);
+                const result = await db.collections.jobs_collection.insertOne(job);
                 jobList.push(job);
                 if (!result.acknowledged) {
                     throw new GraphQLError(errorCodes.DATABASE_ERROR);
@@ -76,6 +79,9 @@ export const jobResolvers = {
             return jobList;
         },
         createFieldCurationJob: async (__unused__parent: Record<string, unknown>, args: { file: string, studyId: string, tag: string }, context: any): Promise<IJobEntryForFieldCuration> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
 
             /* check permission */
@@ -88,7 +94,7 @@ export const jobResolvers = {
             if (!hasPermission) { throw new GraphQLError(errorCodes.NO_PERMISSION_ERROR); }
 
             /* check if the file exists */
-            const file = await db.collections!.files_collection.findOne({ deleted: null, id: args.file });
+            const file = await db.collections.files_collection.findOne({ deleted: null, id: args.file });
             if (!file) {
                 throw new GraphQLError(errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY);
             }
@@ -117,13 +123,16 @@ export const jobResolvers = {
                 }
             };
 
-            const result = await db.collections!.jobs_collection.insertOne(job);
+            const result = await db.collections.jobs_collection.insertOne(job);
             if (!result.acknowledged) {
                 throw new GraphQLError(errorCodes.DATABASE_ERROR);
             }
             return job;
         },
         createQueryCurationJob: async (__unused__parent: Record<string, unknown>, args: { queryId: string[], studyId: string, projectId: string }, context: any): Promise<IJobEntryForQueryCuration> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
 
             /* check permission */
@@ -146,7 +155,7 @@ export const jobResolvers = {
             await studyCore.findOneStudy_throwErrorIfNotExist(args.studyId);
 
             /* check if project exists */
-            const projectExist = await db.collections!.projects_collection.findOne({ id: args.projectId });
+            const projectExist = await db.collections.projects_collection.findOne({ id: args.projectId });
             if (!projectExist) {
                 throw new GraphQLError('Project does not exist.', { extensions: { code: errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY } });
             }
@@ -154,7 +163,7 @@ export const jobResolvers = {
             /* check if the query exists */
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
-            const queryExist = await db.collections!.queries_collection.findOne({ id: args.queryId[0] });
+            const queryExist = await db.collections.queries_collection.findOne({ id: args.queryId[0] });
             if (!queryExist) {
                 throw new GraphQLError('Query does not exist.', { extensions: { code: errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY } });
             }
@@ -175,7 +184,7 @@ export const jobResolvers = {
                     studyId: args.studyId
                 }
             };
-            const result = await db.collections!.jobs_collection.insertOne(job);
+            const result = await db.collections.jobs_collection.insertOne(job);
             if (!result.acknowledged) {
                 throw new GraphQLError(errorCodes.DATABASE_ERROR);
             }

--- a/packages/itmat-interface/src/graphql/resolvers/logResolvers.ts
+++ b/packages/itmat-interface/src/graphql/resolvers/logResolvers.ts
@@ -3,9 +3,20 @@ import { ILogEntry, IUser, LOG_ACTION, userTypes } from '@itmat-broker/itmat-typ
 import { GraphQLError } from 'graphql';
 import { errorCodes } from '../errors';
 
+interface LogObjInput {
+    requesterName?: string;
+    requesterType?: userTypes;
+    logType?: LOG_TYPE;
+    actionType?: LOG_ACTION;
+    status?: LOG_STATUS
+}
+
 export const logResolvers = {
     Query: {
-        getLogs: async (__unused_parent: Record<string, unknown>, args: any, context: any): Promise<ILogEntry[]> => {
+        getLogs: async (__unused_parent: Record<string, unknown>, args: LogObjInput, context: any): Promise<ILogEntry[]> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
 
             /* only admin can access this field */
@@ -13,13 +24,13 @@ export const logResolvers = {
                 throw new GraphQLError(errorCodes.NO_PERMISSION_ERROR);
             }
 
-            const queryObj: Record<string, any> = {};
-            for (const prop in args) {
-                if (args.prop !== undefined) {
-                    queryObj[prop] = args.prop;
+            const queryObj: Record<string, unknown> = {};
+            for (const prop of (Object.keys(args) as Array<keyof LogObjInput>)) {
+                if (args[prop] !== undefined) {
+                    queryObj[prop] = args[prop];
                 }
             }
-            const logData = await db.collections!.log_collection.find<ILogEntry>(queryObj, { projection: { _id: 0 } }).limit(1000).sort('time', -1).toArray();
+            const logData = await db.collections.log_collection.find<ILogEntry>(queryObj, { projection: { _id: 0 } }).limit(1000).sort('time', -1).toArray();
             // log information decoration
             for (const i in logData) {
                 logData[i].actionData = JSON.stringify(await logDecorationHelper(logData[i].actionData, logData[i].actionType));
@@ -36,8 +47,11 @@ export const hiddenFields = {
     UPLOAD_FILE: ['file', 'description']
 };
 
-async function logDecorationHelper(actionData: any, actionType: string) {
-    const obj = JSON.parse(actionData) ?? {};
+async function logDecorationHelper(actionData: string, actionType: string) {
+    if (!db.collections) {
+        throw new GraphQLError(errorCodes.DATABASE_ERROR);
+    }
+    const obj: Record<string, any> = JSON.parse(actionData) ?? {};
     if (Object.keys(hiddenFields).includes(actionType)) {
         for (let i = 0; i < hiddenFields[actionType as keyof typeof hiddenFields].length; i++) {
             delete obj[hiddenFields[actionType as keyof typeof hiddenFields][i]];
@@ -45,7 +59,7 @@ async function logDecorationHelper(actionData: any, actionType: string) {
     }
     if (actionType === LOG_ACTION.getStudy) {
         const studyId = obj['studyId'];
-        const study = await db.collections!.studies_collection.findOne({ id: studyId, deleted: null })!;
+        const study = await db.collections.studies_collection.findOne({ id: studyId, deleted: null })!;
         if (study === null || study === undefined) {
             obj['name'] = '';
         }

--- a/packages/itmat-interface/src/graphql/resolvers/organisationResolvers.ts
+++ b/packages/itmat-interface/src/graphql/resolvers/organisationResolvers.ts
@@ -1,12 +1,17 @@
 import { IOrganisation } from '@itmat-broker/itmat-types';
 import { db } from '../../database/database';
+import { GraphQLError } from 'graphql';
+import { errorCodes } from '../errors';
 
 export const organisationResolvers = {
     Query: {
-        getOrganisations: async (__unused__parent: Record<string, unknown>, args: any): Promise<IOrganisation[]> => {
+        getOrganisations: async (__unused__parent: Record<string, unknown>, args): Promise<IOrganisation[]> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             // everyone is allowed to see all organisations in the app.
             const queryObj = args.organisationId === undefined ? { deleted: null } : { deleted: null, id: args.organisationId };
-            const cursor = db.collections!.organisations_collection.find<IOrganisation>(queryObj, { projection: { _id: 0 } });
+            const cursor = db.collections.organisations_collection.find<IOrganisation>(queryObj, { projection: { _id: 0 } });
             return cursor.toArray();
         }
     },

--- a/packages/itmat-interface/src/graphql/resolvers/studyResolvers.ts
+++ b/packages/itmat-interface/src/graphql/resolvers/studyResolvers.ts
@@ -28,9 +28,14 @@ import { IGenericResponse, makeGenericReponse } from '../responses';
 import { buildPipeline, translateMetadata } from '../../utils/query';
 import { dataStandardization } from '../../utils/query';
 
+type FieldObjInput = Pick<IFieldEntry, 'fieldId' | 'fieldName' | 'tableName' | 'dataType' | 'possibleValues' | 'unit' | 'comments'>;
+
 export const studyResolvers = {
     Query: {
         getStudy: async (__unused__parent: Record<string, unknown>, args: Record<string, string>, context: any): Promise<IStudy | null> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             const studyId: string = args.studyId;
 
@@ -43,18 +48,21 @@ export const studyResolvers = {
             );
             if (!hasPermission) { throw new GraphQLError(errorCodes.NO_PERMISSION_ERROR); }
 
-            const study = await db.collections!.studies_collection.findOne({ id: studyId, deleted: null })!;
+            const study = await db.collections.studies_collection.findOne({ id: studyId, deleted: null })!;
             if (study === null || study === undefined) {
                 throw new GraphQLError(errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY);
             }
             return study;
         },
         getProject: async (__unused__parent: Record<string, unknown>, args: any, context: any): Promise<Omit<IProject, 'patientMapping'> | null> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             const projectId: string = args.projectId;
 
             /* get project */ // defer patientMapping since it's costly and not available to all users
-            const project = await db.collections!.projects_collection.findOne({ id: projectId, deleted: null }, { projection: { patientMapping: 0 } })!;
+            const project = await db.collections.projects_collection.findOne({ id: projectId, deleted: null }, { projection: { patientMapping: 0 } })!;
             if (!project)
                 throw new GraphQLError(errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY);
 
@@ -78,6 +86,9 @@ export const studyResolvers = {
             return project;
         },
         getStudyFields: async (__unused__parent: Record<string, unknown>, { studyId, projectId, versionId }: { studyId: string, projectId?: string, versionId?: string | null }, context: any): Promise<IFieldEntry[]> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             /* user can get study if he has readonly permission */
             const hasStudyLevelPermission = await permissionCore.userHasTheNeccessaryDataPermission(
@@ -93,7 +104,7 @@ export const studyResolvers = {
             );
             if (!hasStudyLevelPermission && !hasProjectLevelPermission) { throw new GraphQLError(errorCodes.NO_PERMISSION_ERROR); }
             const study = await studyCore.findOneStudy_throwErrorIfNotExist(studyId);
-            const aggregatedPermissions: any = permissionCore.combineMultiplePermissions([hasStudyLevelPermission, hasProjectLevelPermission]);
+            const aggregatedPermissions = permissionCore.combineMultiplePermissions([hasStudyLevelPermission, hasProjectLevelPermission]);
 
             // the processes of requiring versioned data and unversioned data are different
             // check the metadata:role:**** for versioned data directly
@@ -103,7 +114,7 @@ export const studyResolvers = {
                 if (versionId === null) {
                     availableDataVersions.push(null);
                 }
-                const fieldRecords: any[] = await db.collections!.field_dictionary_collection.aggregate([{
+                const fieldRecords: any[] = await db.collections.field_dictionary_collection.aggregate([{
                     $match: { studyId: studyId, dateDeleted: null, dataVersion: { $in: availableDataVersions } }
                 }, {
                     $sort: { dateAdded: -1 }
@@ -124,7 +135,7 @@ export const studyResolvers = {
             // unversioned data could not be returned by metadata filters
             if (versionId === null && aggregatedPermissions.hasVersioned) {
                 availableDataVersions.push(null);
-                const fieldRecords: any[] = await db.collections!.field_dictionary_collection.aggregate([{
+                const fieldRecords: any[] = await db.collections.field_dictionary_collection.aggregate([{
                     $match: { studyId: studyId, dataVersion: { $in: availableDataVersions } }
                 }, {
                     $sort: { dateAdded: -1 }
@@ -147,12 +158,12 @@ export const studyResolvers = {
                 return fieldRecords;
             } else {
                 // metadata filter
-                const subqueries: any = [];
-                aggregatedPermissions.matchObj.forEach((subMetadata: any) => {
+                const subqueries: any[] = [];
+                aggregatedPermissions.matchObj.forEach((subMetadata) => {
                     subqueries.push(translateMetadata(subMetadata));
                 });
                 const metadataFilter = { $or: subqueries };
-                const fieldRecords: any[] = await db.collections!.field_dictionary_collection.aggregate([{
+                const fieldRecords: any[] = await db.collections.field_dictionary_collection.aggregate([{
                     $match: { studyId: studyId, dateDeleted: null, dataVersion: { $in: availableDataVersions } }
                 }, {
                     $sort: { dateAdded: -1 }
@@ -240,6 +251,9 @@ export const studyResolvers = {
             }
         },
         checkDataComplete: async (__unused__parent: Record<string, unknown>, { studyId }: { studyId: string }, context: any): Promise<any> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             /* user can get study if he has readonly permission */
             const hasPermission = await permissionCore.userHasTheNeccessaryDataPermission(
@@ -251,14 +265,14 @@ export const studyResolvers = {
                 throw new GraphQLError(errorCodes.NO_PERMISSION_ERROR);
             }
             // we only check data that hasnt been pushed to a new data version
-            const data: IDataEntry[] = await db.collections!.data_collection.find({
+            const data: IDataEntry[] = await db.collections.data_collection.find({
                 m_studyId: studyId,
                 m_versionId: null,
                 m_subjectId: { $in: hasPermission.raw.subjectIds.map((el: string) => new RegExp(el)) },
                 m_visitId: { $in: hasPermission.raw.visitIds.map((el: string) => new RegExp(el)) },
                 m_fieldId: { $in: hasPermission.raw.fieldIds.map((el: string) => new RegExp(el)) }
             }).toArray();
-            const fieldMapping = (await db.collections!.field_dictionary_collection.aggregate([{
+            const fieldMapping = (await db.collections.field_dictionary_collection.aggregate([{
                 $match: { studyId: studyId }
             }, {
                 $match: { fieldId: { $in: hasPermission.raw.fieldIds.map((el: string) => new RegExp(el)) } }
@@ -317,7 +331,7 @@ export const studyResolvers = {
                             break;
                         }
                         case 'file': {
-                            const file = await db.collections!.files_collection.findOne({ id: record.value });
+                            const file = await db.collections.files_collection.findOne({ id: record.value });
                             if (!file) {
                                 error = `Field ${record.m_fieldId}: Cannot parse as file or file does not exist.`;
                                 break;
@@ -348,6 +362,9 @@ export const studyResolvers = {
             return summary;
         },
         getDataRecords: async (__unused__parent: Record<string, unknown>, { studyId, queryString, versionId, projectId }: { queryString: any, studyId: string, versionId: string | null | undefined, projectId?: string }, context: any): Promise<any> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             /* user can get study if he has readonly permission */
             const hasStudyLevelPermission = await permissionCore.userHasTheNeccessaryDataPermission(
@@ -364,12 +381,12 @@ export const studyResolvers = {
             if (!hasStudyLevelPermission && !hasProjectLevelPermission) { throw new GraphQLError(errorCodes.NO_PERMISSION_ERROR); }
 
             const study = await studyCore.findOneStudy_throwErrorIfNotExist(studyId);
-            const aggregatedPermissions: any = permissionCore.combineMultiplePermissions([hasStudyLevelPermission, hasProjectLevelPermission]);
+            const aggregatedPermissions = permissionCore.combineMultiplePermissions([hasStudyLevelPermission, hasProjectLevelPermission]);
 
             let availableDataVersions: Array<string | null> = (study.currentDataVersion === -1 ? [] : study.dataVersions.filter((__unused__el, index) => index <= study.currentDataVersion)).map(el => el.id);
             let fieldRecords: any[] = [];
-            let result: any;
-            let metadataFilter: any = undefined;
+            let result;
+            let metadataFilter = undefined;
             // we obtain the data by different requests
             // admin used will not filtered by metadata filters
             if (requester.type === userTypes.ADMIN) {
@@ -380,7 +397,7 @@ export const studyResolvers = {
                     availableDataVersions = availableDataVersions.length !== 0 ? [availableDataVersions[availableDataVersions.length - 1]] : [];
                 }
 
-                fieldRecords = await db.collections!.field_dictionary_collection.aggregate([{
+                fieldRecords = await db.collections.field_dictionary_collection.aggregate([{
                     $match: { studyId: studyId, dateDeleted: null, dataVersion: { $in: availableDataVersions } }
                 }, {
                     $sort: { dateAdded: -1 }
@@ -400,17 +417,17 @@ export const studyResolvers = {
                     fieldRecords = fieldRecords.filter(el => queryString.data_requested.includes(el.fieldId));
                 }
                 const pipeline = buildPipeline(queryString, studyId, availableDataVersions, fieldRecords, undefined, true, versionId === null);
-                result = await db.collections!.data_collection.aggregate(pipeline, { allowDiskUse: true }).toArray();
+                result = await db.collections.data_collection.aggregate(pipeline, { allowDiskUse: true }).toArray();
             } else {
-                const subqueries: any = [];
-                aggregatedPermissions.matchObj.forEach((subMetadata: any) => {
+                const subqueries: any[] = [];
+                aggregatedPermissions.matchObj.forEach((subMetadata) => {
                     subqueries.push(translateMetadata(subMetadata));
                 });
                 metadataFilter = { $or: subqueries };
                 // unversioned data: metadatafilter for versioned data and all unversioned tags
                 if (versionId === null && aggregatedPermissions.hasVersioned) {
                     availableDataVersions.push(null);
-                    fieldRecords = await db.collections!.field_dictionary_collection.aggregate([{
+                    fieldRecords = await db.collections.field_dictionary_collection.aggregate([{
                         $match: { studyId: studyId, dateDeleted: null, dataVersion: { $in: availableDataVersions } }
                     }, {
                         $sort: { dateAdded: -1 }
@@ -440,7 +457,7 @@ export const studyResolvers = {
                     if (versionId === '-1') {
                         availableDataVersions = availableDataVersions.length !== 0 ? [availableDataVersions[availableDataVersions.length - 1]] : [];
                     }
-                    fieldRecords = await db.collections!.field_dictionary_collection.aggregate([{
+                    fieldRecords = await db.collections.field_dictionary_collection.aggregate([{
                         $match: { studyId: studyId, dateDeleted: null, dataVersion: { $in: availableDataVersions } }
                     }, {
                         $sort: { dateAdded: -1 }
@@ -469,10 +486,10 @@ export const studyResolvers = {
 
                 // TODO: placeholder for metadata filter
                 // if (queryString.metadata) {
-                //     metadataFilter = { $and: queryString.metadata.map((el: any) => translateMetadata(el)) };
+                //     metadataFilter = { $and: queryString.metadata.map((el) => translateMetadata(el)) };
                 // }
                 const pipeline = buildPipeline(queryString, studyId, availableDataVersions, fieldRecords, metadataFilter, false, versionId === null && aggregatedPermissions.hasVersioned);
-                result = await db.collections!.data_collection.aggregate(pipeline, { allowDiskUse: true }).toArray();
+                result = await db.collections.data_collection.aggregate(pipeline, { allowDiskUse: true }).toArray();
             }
             // post processing the data
             // 2. update to the latest data; start from first record
@@ -490,23 +507,35 @@ export const studyResolvers = {
 
             // 2. adjust format: 1) original(exists) 2) standardized - $name 3) grouped
             // when standardized data, versionId should not be specified
-            const standardizations = versionId === null ? null : await db.collections!.standardizations_collection.find({ studyId: studyId, type: queryString['format'].split('-')[1], delete: null, dataVersion: { $in: availableDataVersions } }).toArray();
+            const standardizations = versionId === null ? null : await db.collections.standardizations_collection.find({ studyId: studyId, type: queryString['format'].split('-')[1], delete: null, dataVersion: { $in: availableDataVersions } }).toArray();
             const formattedData = dataStandardization(study, fieldRecords,
-                groupedResult, queryString, standardizations);
+                groupedResult, queryString, standardizations as any);
             return { data: formattedData };
         }
     },
     Study: {
         projects: async (study: IStudy): Promise<Array<IProject>> => {
-            return await db.collections!.projects_collection.find({ studyId: study.id, deleted: null }).toArray();
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
+            return await db.collections.projects_collection.find({ studyId: study.id, deleted: null }).toArray();
         },
         jobs: async (study: IStudy): Promise<Array<IJobEntry<any>>> => {
-            return await db.collections!.jobs_collection.find({ studyId: study.id }).toArray();
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
+            return await db.collections.jobs_collection.find({ studyId: study.id }).toArray();
         },
         roles: async (study: IStudy): Promise<Array<IRole>> => {
-            return await db.collections!.roles_collection.find({ studyId: study.id, projectId: undefined, deleted: null }).toArray();
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
+            return await db.collections.roles_collection.find({ studyId: study.id, projectId: undefined, deleted: null }).toArray();
         },
         files: async (study: IStudy, __unused__args: never, context: any): Promise<Array<IFile>> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             const hasPermission = await permissionCore.userHasTheNeccessaryDataPermission(
                 atomicOperation.READ,
@@ -519,7 +548,7 @@ export const studyResolvers = {
             }
 
             const availableDataVersions: Array<string | null> = (study.currentDataVersion === -1 ? [] : study.dataVersions.filter((__unused__el, index) => index <= study.currentDataVersion)).map(el => el.id);
-            const fileFieldIds: string[] = (await db.collections!.field_dictionary_collection.aggregate([{
+            const fileFieldIds: string[] = (await db.collections.field_dictionary_collection.aggregate([{
                 $match: { studyId: study.id, dateDeleted: null, dataVersion: { $in: availableDataVersions }, dataType: enumValueType.FILE }
             }, { $match: { fieldId: { $in: hasPermission.raw.fieldIds.map((el: string) => new RegExp(el)) } } }, {
                 $sort: { dateAdded: -1 }
@@ -540,18 +569,18 @@ export const studyResolvers = {
 
             // versioned data
             if (requester.type === userTypes.ADMIN) {
-                const fileRecords = await db.collections!.data_collection.aggregate([{
+                const fileRecords = await db.collections.data_collection.aggregate([{
                     $match: { m_studyId: study.id, m_fieldId: { $in: fileFieldIds } }
                 }]).toArray();
                 adds = fileRecords.map(el => el.metadata?.add || []).flat();
                 removes = fileRecords.map(el => el.metadata?.remove || []).flat();
             } else {
-                const subqueries: any = [];
+                const subqueries: any[] = [];
                 hasPermission.matchObj.forEach((subMetadata: any) => {
                     subqueries.push(translateMetadata(subMetadata));
                 });
                 const metadataFilter = { $or: subqueries };
-                const versionedFileRecors = await db.collections!.data_collection.aggregate([{
+                const versionedFileRecors = await db.collections.data_collection.aggregate([{
                     $match: { m_studyId: study.id, m_versionId: { $in: availableDataVersions }, m_fieldId: { $in: fileFieldIds } }
                 }, {
                     $match: metadataFilter
@@ -571,7 +600,7 @@ export const studyResolvers = {
                 }
                 let unversionedFileRecords: any[] = [];
                 if (filters.length !== 0) {
-                    unversionedFileRecords = await db.collections!.data_collection.aggregate([{
+                    unversionedFileRecords = await db.collections.data_collection.aggregate([{
                         $match: { m_studyId: study.id, m_versionId: null, m_fieldId: { $in: fileFieldIds } }
                     }, {
                         $match: { $or: filters }
@@ -582,9 +611,12 @@ export const studyResolvers = {
                 adds = adds.concat(unversionedFileRecords.map(el => el.metadata?.add || []).flat());
                 removes = removes.concat(unversionedFileRecords.map(el => el.metadata?.remove || []).flat());
             }
-            return await db.collections!.files_collection.find({ studyId: study.id, deleted: null, $or: [{ id: { $in: adds, $nin: removes } }, { description: JSON.stringify({}) }] }).sort({ uploadTime: -1 }).toArray();
+            return await db.collections.files_collection.find({ studyId: study.id, deleted: null, $or: [{ id: { $in: adds, $nin: removes } }, { description: JSON.stringify({}) }] }).sort({ uploadTime: -1 }).toArray();
         },
         subjects: async (study: IStudy, __unused__args: never, context: any): Promise<Array<Array<string>>> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             const hasPermission = await permissionCore.userHasTheNeccessaryDataPermission(
                 atomicOperation.READ,
@@ -595,7 +627,7 @@ export const studyResolvers = {
                 return [[], []];
             }
             const availableDataVersions: Array<string> = (study.currentDataVersion === -1 ? [] : study.dataVersions.filter((__unused__el, index) => index <= study.currentDataVersion)).map(el => el.id);
-            const versionedSubjects = (await db.collections!.data_collection.distinct('m_subjectId', {
+            const versionedSubjects = (await db.collections.data_collection.distinct('m_subjectId', {
                 m_studyId: study.id,
                 m_versionId: { $in: availableDataVersions },
                 m_subjectId: { $in: hasPermission.raw.subjectIds.map((el: string) => new RegExp(el)) },
@@ -603,7 +635,7 @@ export const studyResolvers = {
                 m_fieldId: { $in: hasPermission.raw.fieldIds.map((el: string) => new RegExp(el)) },
                 value: { $ne: null }
             })).sort() || [];
-            const unVersionedSubjects = hasPermission.hasVersioned ? (await db.collections!.data_collection.distinct('m_subjectId', {
+            const unVersionedSubjects = hasPermission.hasVersioned ? (await db.collections.data_collection.distinct('m_subjectId', {
                 m_studyId: study.id,
                 m_versionId: { $in: [null] },
                 m_subjectId: { $in: hasPermission.raw.subjectIds.map((el: string) => new RegExp(el)) },
@@ -614,6 +646,9 @@ export const studyResolvers = {
             return [versionedSubjects, unVersionedSubjects];
         },
         visits: async (study: IStudy, __unused__args: never, context: any): Promise<Array<Array<string>>> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             const hasPermission = await permissionCore.userHasTheNeccessaryDataPermission(
                 atomicOperation.READ,
@@ -624,7 +659,7 @@ export const studyResolvers = {
                 return [[], []];
             }
             const availableDataVersions: Array<string> = (study.currentDataVersion === -1 ? [] : study.dataVersions.filter((__unused__el, index) => index <= study.currentDataVersion)).map(el => el.id);
-            const versionedVisits = (await db.collections!.data_collection.distinct('m_visitId', {
+            const versionedVisits = (await db.collections.data_collection.distinct('m_visitId', {
                 m_studyId: study.id,
                 m_versionId: { $in: availableDataVersions },
                 m_subjectId: { $in: hasPermission.raw.subjectIds.map((el: string) => new RegExp(el)) },
@@ -632,7 +667,7 @@ export const studyResolvers = {
                 m_fieldId: { $in: hasPermission.raw.fieldIds.map((el: string) => new RegExp(el)) },
                 value: { $ne: null }
             })).sort((a, b) => parseFloat(a) - parseFloat(b));
-            const unVersionedVisits = hasPermission.hasVersioned ? (await db.collections!.data_collection.distinct('m_visitId', {
+            const unVersionedVisits = hasPermission.hasVersioned ? (await db.collections.data_collection.distinct('m_visitId', {
                 m_studyId: study.id,
                 m_versionId: { $in: [null] },
                 m_subjectId: { $in: hasPermission.raw.subjectIds.map((el: string) => new RegExp(el)) },
@@ -643,6 +678,9 @@ export const studyResolvers = {
             return [versionedVisits, unVersionedVisits];
         },
         numOfRecords: async (study: IStudy, __unused__args: never, context: any): Promise<number[]> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             const hasPermission = await permissionCore.userHasTheNeccessaryDataPermission(
                 atomicOperation.READ,
@@ -653,7 +691,7 @@ export const studyResolvers = {
                 return [0, 0];
             }
             const availableDataVersions: Array<string | null> = (study.currentDataVersion === -1 ? [] : study.dataVersions.filter((__unused__el, index) => index <= study.currentDataVersion)).map(el => el.id);
-            const numberOfVersioned: number = (await db.collections!.data_collection.aggregate([{
+            const numberOfVersioned: number = (await db.collections.data_collection.aggregate([{
                 $match: { m_studyId: study.id, m_versionId: { $in: availableDataVersions }, value: { $ne: null } }
             }, {
                 $match: {
@@ -664,7 +702,7 @@ export const studyResolvers = {
             }, {
                 $count: 'count'
             }]).toArray())[0]?.count || 0;
-            const numberOfUnVersioned: number = hasPermission.hasVersioned ? (await db.collections!.data_collection.aggregate([{
+            const numberOfUnVersioned: number = hasPermission.hasVersioned ? (await db.collections.data_collection.aggregate([{
                 $match: { m_studyId: study.id, m_versionId: { $in: [null] }, value: { $ne: null } }
             }, {
                 $match: {
@@ -683,6 +721,9 @@ export const studyResolvers = {
     },
     Project: {
         fields: async (project: Omit<IProject, 'patientMapping'>, __unused__args: never, context: any): Promise<Array<Partial<IFieldEntry>>> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             const hasProjectLevelPermission = await permissionCore.userHasTheNeccessaryDataPermission(
                 atomicOperation.READ,
@@ -714,7 +755,7 @@ export const studyResolvers = {
             const ontologyTreeFieldIds: string[] = (availableTrees[0].routes || []).map(el => el.field[0].replace('$', ''));
             let fieldRecords: any[] = [];
             if (requester.type === userTypes.ADMIN) {
-                fieldRecords = await db.collections!.field_dictionary_collection.aggregate([{
+                fieldRecords = await db.collections.field_dictionary_collection.aggregate([{
                     $match: { studyId: project.studyId, dateDeleted: null, dataVersion: { $in: availableDataVersions }, fieldId: { $in: ontologyTreeFieldIds } }
                 }, {
                     $group: {
@@ -732,12 +773,12 @@ export const studyResolvers = {
                 }]).toArray();
             } else {
                 // metadata filter
-                const subqueries: any = [];
+                const subqueries: any[] = [];
                 hasProjectLevelPermission.matchObj.forEach((subMetadata: any) => {
                     subqueries.push(translateMetadata(subMetadata));
                 });
                 const metadataFilter = { $or: subqueries };
-                fieldRecords = await db.collections!.field_dictionary_collection.aggregate([{
+                fieldRecords = await db.collections.field_dictionary_collection.aggregate([{
                     $match: { studyId: project.studyId, dateDeleted: null, dataVersion: { $in: availableDataVersions }, fieldId: { $in: ontologyTreeFieldIds } }
                 }, { $match: metadataFilter }, {
                     $group: {
@@ -757,9 +798,15 @@ export const studyResolvers = {
             return fieldRecords;
         },
         jobs: async (project: Omit<IProject, 'patientMapping'>): Promise<Array<IJobEntry<any>>> => {
-            return await db.collections!.jobs_collection.find({ studyId: project.studyId, projectId: project.id }).toArray();
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
+            return await db.collections.jobs_collection.find({ studyId: project.studyId, projectId: project.id }).toArray();
         },
         files: async (project: Omit<IProject, 'patientMapping'>, __unused__args: never, context: any): Promise<Array<IFile>> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             const hasPermission = await permissionCore.userHasTheNeccessaryDataPermission(
                 atomicOperation.READ,
@@ -786,7 +833,7 @@ export const studyResolvers = {
                 return [];
             }
             const ontologyTreeFieldIds: string[] = (availableTrees[0].routes || []).map(el => el.field[0].replace('$', ''));
-            const fileFieldIds: string[] = (await db.collections!.field_dictionary_collection.aggregate([{
+            const fileFieldIds: string[] = (await db.collections.field_dictionary_collection.aggregate([{
                 $match: { studyId: study.id, dateDeleted: null, dataVersion: { $in: availableDataVersions }, dataType: enumValueType.FILE }
             }, { $match: { $and: [{ fieldId: { $in: hasPermission.raw.fieldIds.map((el: string) => new RegExp(el)) } }, { fieldId: { $in: ontologyTreeFieldIds } }] } }, {
                 $group: {
@@ -803,19 +850,19 @@ export const studyResolvers = {
             let add: string[] = [];
             let remove: string[] = [];
             if (Object.keys(hasPermission.matchObj).length === 0) {
-                (await db.collections!.data_collection.aggregate([{
+                (await db.collections.data_collection.aggregate([{
                     $match: { m_studyId: study.id, m_versionId: { $in: availableDataVersions }, m_fieldId: { $in: fileFieldIds } }
                 }]).toArray()).forEach(element => {
                     add = add.concat(element.metadata?.add || []);
                     remove = remove.concat(element.metadata?.remove || []);
                 });
             } else {
-                const subqueries: any = [];
+                const subqueries: any[] = [];
                 hasPermission.matchObj.forEach((subMetadata: any) => {
                     subqueries.push(translateMetadata(subMetadata));
                 });
                 const metadataFilter = { $or: subqueries };
-                (await db.collections!.data_collection.aggregate([{
+                (await db.collections.data_collection.aggregate([{
                     $match: { m_studyId: study.id, m_versionId: { $in: availableDataVersions }, m_fieldId: { $in: fileFieldIds } }
                 }, {
                     $match: metadataFilter
@@ -824,10 +871,13 @@ export const studyResolvers = {
                     remove = remove.concat(element.metadata?.remove || []);
                 });
             }
-            return await db.collections!.files_collection.find({ $and: [{ id: { $in: add } }, { id: { $nin: remove } }] }).toArray();
+            return await db.collections.files_collection.find({ $and: [{ id: { $in: add } }, { id: { $nin: remove } }] }).toArray();
         },
         dataVersion: async (project: IProject): Promise<IStudyDataVersion | null> => {
-            const study = await db.collections!.studies_collection.findOne({ id: project.studyId, deleted: null });
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
+            const study = await db.collections.studies_collection.findOne({ id: project.studyId, deleted: null });
             if (study === undefined || study === null) {
                 return null;
             }
@@ -837,8 +887,11 @@ export const studyResolvers = {
             return study.dataVersions[study?.currentDataVersion];
         },
         summary: async (project: IProject, __unused__args: never, context: any): Promise<any> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const summary: any = {};
-            const study = await db.collections!.studies_collection.findOne({ id: project.studyId });
+            const study = await db.collections.studies_collection.findOne({ id: project.studyId });
             if (study === undefined || study === null || study.currentDataVersion === -1) {
                 return summary;
             }
@@ -858,9 +911,9 @@ export const studyResolvers = {
             );
             if (!hasStudyLevelPermission && !hasProjectLevelPermission) { throw new GraphQLError(errorCodes.NO_PERMISSION_ERROR); }
             // get all dataVersions that are valid (before the current version)
-            const aggregatedPermissions: any = permissionCore.combineMultiplePermissions([hasStudyLevelPermission, hasProjectLevelPermission]);
+            const aggregatedPermissions = permissionCore.combineMultiplePermissions([hasStudyLevelPermission, hasProjectLevelPermission]);
 
-            let metadataFilter: any = undefined;
+            let metadataFilter = undefined;
 
             const availableDataVersions = (study.currentDataVersion === -1 ? [] : study.dataVersions.filter((__unused__el, index) => index <= study.currentDataVersion)).map(el => el.id);
             // ontology trees
@@ -878,7 +931,7 @@ export const studyResolvers = {
 
             let fieldRecords;
             if (requester.type === userTypes.ADMIN) {
-                fieldRecords = await db.collections!.field_dictionary_collection.aggregate([{
+                fieldRecords = await db.collections.field_dictionary_collection.aggregate([{
                     $match: { studyId: project.studyId, dateDeleted: null, dataVersion: { $in: availableDataVersions } }
                 }, {
                     $group: {
@@ -891,12 +944,12 @@ export const studyResolvers = {
                     }
                 }]).toArray();
             } else {
-                const subqueries: any = [];
-                aggregatedPermissions.matchObj.forEach((subMetadata: any) => {
+                const subqueries: any[] = [];
+                aggregatedPermissions.matchObj.forEach((subMetadata) => {
                     subqueries.push(translateMetadata(subMetadata));
                 });
                 metadataFilter = { $or: subqueries };
-                fieldRecords = await db.collections!.field_dictionary_collection.aggregate([{
+                fieldRecords = await db.collections.field_dictionary_collection.aggregate([{
                     $match: { studyId: project.studyId, dateDeleted: null, dataVersion: { $in: availableDataVersions } }
                 }, { $match: metadataFilter }, {
                     $group: {
@@ -911,13 +964,16 @@ export const studyResolvers = {
             }
             // fieldRecords = fieldRecords.filter(el => ontologyTreeFieldIds.includes(el.fieldId));
             const pipeline = buildPipeline({}, project.studyId, availableDataVersions, fieldRecords as IFieldEntry[], metadataFilter, requester.type === userTypes.ADMIN, false);
-            const result = await db.collections!.data_collection.aggregate(pipeline, { allowDiskUse: true }).toArray();
-            summary['subjects'] = Array.from(new Set(result.map((el: any) => el.m_subjectId))).sort();
-            summary['visits'] = Array.from(new Set(result.map((el: any) => el.m_visitId))).sort((a, b) => parseFloat(a) - parseFloat(b)).sort();
-            summary['standardizationTypes'] = (await db.collections!.standardizations_collection.distinct('type', { studyId: study.id, deleted: null })).sort();
+            const result = await db.collections.data_collection.aggregate(pipeline, { allowDiskUse: true }).toArray();
+            summary['subjects'] = Array.from(new Set(result.map((el) => el.m_subjectId))).sort();
+            summary['visits'] = Array.from(new Set(result.map((el) => el.m_visitId))).sort((a, b) => parseFloat(a) - parseFloat(b)).sort();
+            summary['standardizationTypes'] = (await db.collections.standardizations_collection.distinct('type', { studyId: study.id, deleted: null })).sort();
             return summary;
         },
         patientMapping: async (project: Omit<IProject, 'patientMapping'>, __unused__args: never, context: any): Promise<any> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             /* check privileges */
             if (!(await permissionCore.userHasTheNeccessaryDataPermission(
@@ -930,7 +986,7 @@ export const studyResolvers = {
 
             /* returning */
             const result =
-                await db.collections!.projects_collection.findOne(
+                await db.collections.projects_collection.findOne(
                     { id: project.id, deleted: null },
                     { projection: { patientMapping: 1 } }
                 );
@@ -941,10 +997,16 @@ export const studyResolvers = {
             }
         },
         roles: async (project: IProject): Promise<Array<any>> => {
-            return await db.collections!.roles_collection.find({ studyId: project.studyId, projectId: project.id, deleted: null }).toArray();
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
+            return await db.collections.roles_collection.find({ studyId: project.studyId, projectId: project.id, deleted: null }).toArray();
         },
         iCanEdit: async (project: IProject): Promise<boolean> => { // TO_DO
-            await db.collections!.roles_collection.findOne({
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
+            await db.collections.roles_collection.findOne({
                 studyId: project.studyId,
                 projectId: project.id
                 // permissions: permissions.specific_project.specifi
@@ -954,6 +1016,9 @@ export const studyResolvers = {
     },
     Mutation: {
         createStudy: async (__unused__parent: Record<string, unknown>, { name, description, type }: { name: string, description: string, type: studyType }, context: any): Promise<IStudy> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
 
             /* check privileges */
@@ -966,6 +1031,9 @@ export const studyResolvers = {
             return study;
         },
         editStudy: async (__unused__parent: Record<string, unknown>, { studyId, description }: { studyId: string, description: string }, context: any): Promise<IStudy> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
 
             /* check privileges */
@@ -977,7 +1045,10 @@ export const studyResolvers = {
             const study = await studyCore.editStudy(studyId, description);
             return study;
         },
-        createNewField: async (__unused__parent: Record<string, unknown>, { studyId, fieldInput }: { studyId: string, fieldInput: any[] }, context: any): Promise<IGenericResponse[]> => {
+        createNewField: async (__unused__parent: Record<string, unknown>, { studyId, fieldInput }: { studyId: string, fieldInput: Array<FieldObjInput> }, context: any): Promise<IGenericResponse[]> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             /* check privileges */
             /* user can get study if he has readonly permission */
@@ -995,9 +1066,9 @@ export const studyResolvers = {
 
             const response: IGenericResponse[] = [];
             let isError = false;
-            const bulk = db.collections!.field_dictionary_collection.initializeUnorderedBulkOp();
+            const bulk = db.collections.field_dictionary_collection.initializeUnorderedBulkOp();
             // remove duplicates by fieldId
-            const keysToCheck = ['fieldId'];
+            const keysToCheck: Array<keyof FieldObjInput> = ['fieldId'];
             const filteredFieldInput = fieldInput.filter(
                 (s => o => (k => !s.has(k) && s.add(k))(keysToCheck.map(k => o[k]).join('|')))(new Set())
             );
@@ -1022,7 +1093,7 @@ export const studyResolvers = {
                     fieldEntry.id = uuid();
                     fieldEntry.studyId = studyId;
                     fieldEntry.dataVersion = null;
-                    fieldEntry.dateAdded = (new Date()).valueOf();
+                    fieldEntry.dateAdded = `${(new Date()).valueOf()}`;
                     fieldEntry.dateDeleted = null;
                     fieldEntry.metadata = {
                         uploader: requester.id
@@ -1039,7 +1110,10 @@ export const studyResolvers = {
             }
             return response;
         },
-        editField: async (__unused__parent: Record<string, unknown>, { studyId, fieldInput }: { studyId: string, fieldInput: any }, context: any): Promise<IFieldEntry> => {
+        editField: async (__unused__parent: Record<string, unknown>, { studyId, fieldInput }: { studyId: string, fieldInput: FieldObjInput }, context: any): Promise<IFieldEntry> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             /* check privileges */
             if (requester.type !== userTypes.ADMIN) {
@@ -1047,24 +1121,27 @@ export const studyResolvers = {
             }
 
             // check fieldId exist
-            const searchField = await db.collections!.field_dictionary_collection.findOne({ studyId: studyId, fieldId: fieldInput.fieldId, dateDeleted: null });
+            const searchField = await db.collections.field_dictionary_collection.findOne({ studyId: studyId, fieldId: fieldInput.fieldId, dateDeleted: null });
             if (!searchField) {
                 throw new GraphQLError('Field does not exist.', { extensions: { code: errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY } });
             }
             for (const each of Object.keys(fieldInput) as Array<keyof IFieldEntry>) {
-                searchField[each] = fieldInput[each];
+                searchField[each] = (fieldInput as any)[each];
             }
             const { fieldEntry, error } = validateAndGenerateFieldEntry(searchField, requester);
             if (error.length !== 0) {
                 throw new GraphQLError(JSON.stringify(error), { extensions: { code: errorCodes.CLIENT_MALFORMED_INPUT } });
             }
             const newFieldEntry = { ...fieldEntry, id: searchField.id, dateAdded: searchField.dateAdded, deleted: searchField.dateDeleted, studyId: searchField.studyId };
-            await db.collections!.field_dictionary_collection.findOneAndUpdate({ studyId: studyId, fieldId: newFieldEntry.fieldId }, { $set: newFieldEntry });
+            await db.collections.field_dictionary_collection.findOneAndUpdate({ studyId: studyId, fieldId: newFieldEntry.fieldId }, { $set: newFieldEntry });
 
             return newFieldEntry;
 
         },
         deleteField: async (__unused__parent: Record<string, unknown>, { studyId, fieldId }: { studyId: string, fieldId: string }, context: any): Promise<IFieldEntry> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
             /* check privileges */
             const hasPermission = await permissionCore.userHasTheNeccessaryDataPermission(
@@ -1081,12 +1158,12 @@ export const studyResolvers = {
             }
 
             // check fieldId exist
-            const searchField = await db.collections!.field_dictionary_collection.find({ studyId: studyId, fieldId: fieldId }).limit(1).sort({ dateAdded: -1 }).toArray();
+            const searchField = await db.collections.field_dictionary_collection.find({ studyId: studyId, fieldId: fieldId }).limit(1).sort({ dateAdded: -1 }).toArray();
             if (searchField.length === 0 || searchField[0].dateDeleted !== null) {
                 throw new GraphQLError('Field does not exist.', { extensions: { code: errorCodes.CLIENT_ACTION_ON_NON_EXISTENT_ENTRY } });
             }
 
-            const fieldEntry: any = {
+            const fieldEntry = {
                 id: uuid(),
                 studyId: studyId,
                 fieldId: searchField[0].fieldId,
@@ -1100,12 +1177,12 @@ export const studyResolvers = {
                 dateAdded: (new Date()).valueOf(),
                 dateDeleted: (new Date()).valueOf()
             };
-            await db.collections!.field_dictionary_collection.findOneAndUpdate({
+            await db.collections.field_dictionary_collection.findOneAndUpdate({
                 fieldId: searchField[0].fieldId,
                 studyId: studyId,
                 dataVersion: null
             }, {
-                $set: fieldEntry
+                $set: fieldEntry as any
             }, {
                 upsert: true
             });
@@ -1114,6 +1191,9 @@ export const studyResolvers = {
 
         },
         uploadDataInArray: async (__unused__parent: Record<string, unknown>, { studyId, data }: { studyId: string, data: IDataClip[] }, context: any): Promise<IGenericResponse[]> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             // check study exists
             const study = await studyCore.findOneStudy_throwErrorIfNotExist(studyId);
 
@@ -1132,7 +1212,7 @@ export const studyResolvers = {
             // find the fieldsList, including those that have not been versioned, same method as getStudyFields
             // get all dataVersions that are valid (before/equal the current version)
             const availableDataVersions = (study.currentDataVersion === -1 ? [] : study.dataVersions.filter((__unused__el, index) => index <= study.currentDataVersion)).map(el => el.id);
-            const fieldRecords = await db.collections!.field_dictionary_collection.aggregate([{
+            const fieldRecords = await db.collections.field_dictionary_collection.aggregate([{
                 $sort: { dateAdded: -1 }
             }, {
                 $match: { $or: [{ dataVersion: null }, { dataVersion: { $in: availableDataVersions } }] }
@@ -1152,6 +1232,9 @@ export const studyResolvers = {
             return response;
         },
         deleteDataRecords: async (__unused__parent: Record<string, unknown>, { studyId, subjectIds, visitIds, fieldIds }: { studyId: string, subjectIds: string[], visitIds: string[], fieldIds: string[] }, context: any): Promise<IGenericResponse[]> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             // check study exists
             await studyCore.findOneStudy_throwErrorIfNotExist(studyId);
             const response: IGenericResponse[] = [];
@@ -1168,25 +1251,25 @@ export const studyResolvers = {
 
             let validSubjects: string[];
             let validVisits: string[];
-            let validFields: any;
+            let validFields;
             // filter
             if (subjectIds === undefined || subjectIds === null || subjectIds.length === 0) {
-                validSubjects = (await db.collections!.data_collection.distinct('m_subjectId', { m_studyId: studyId }));
+                validSubjects = (await db.collections.data_collection.distinct('m_subjectId', { m_studyId: studyId }));
             } else {
                 validSubjects = subjectIds;
             }
             if (visitIds === undefined || visitIds === null || visitIds.length === 0) {
-                validVisits = (await db.collections!.data_collection.distinct('m_visitId', { m_studyId: studyId }));
+                validVisits = (await db.collections.data_collection.distinct('m_visitId', { m_studyId: studyId }));
             } else {
                 validVisits = visitIds;
             }
             if (fieldIds === undefined || fieldIds === null || fieldIds.length === 0) {
-                validFields = (await db.collections!.field_dictionary_collection.distinct('fieldId', { studyId: studyId }));
+                validFields = (await db.collections.field_dictionary_collection.distinct('fieldId', { studyId: studyId }));
             } else {
                 validFields = fieldIds;
             }
 
-            const bulk = db.collections!.data_collection.initializeUnorderedBulkOp();
+            const bulk = db.collections.data_collection.initializeUnorderedBulkOp();
             for (const subjectId of validSubjects) {
                 for (const visitId of validVisits) {
                     for (const fieldId of validFields) {
@@ -1215,6 +1298,9 @@ export const studyResolvers = {
             return response;
         },
         createNewDataVersion: async (__unused__parent: Record<string, unknown>, { studyId, dataVersion, tag }: { studyId: string, dataVersion: string, tag: string }, context: any): Promise<IStudyDataVersion> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             // check study exists
             await studyCore.findOneStudy_throwErrorIfNotExist(studyId);
 
@@ -1237,6 +1323,9 @@ export const studyResolvers = {
             return created;
         },
         createOntologyTree: async (__unused__parent: Record<string, unknown>, { studyId, ontologyTree }: { studyId: string, ontologyTree: Pick<IOntologyTree, 'name' | 'routes'> }, context: any): Promise<IOntologyTree> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             /* check study exists */
             const study = await studyCore.findOneStudy_throwErrorIfNotExist(studyId);
 
@@ -1253,7 +1342,7 @@ export const studyResolvers = {
 
             // in case of old documents whose ontologyTrees are invalid
             if (study.ontologyTrees === undefined || study.ontologyTrees === null) {
-                await db.collections!.studies_collection.findOneAndUpdate({ id: studyId, deleted: null }, {
+                await db.collections.studies_collection.findOneAndUpdate({ id: studyId, deleted: null }, {
                     $set: {
                         ontologyTrees: []
                     }
@@ -1266,7 +1355,7 @@ export const studyResolvers = {
                 el.id = uuid();
                 el.visitRange = el.visitRange || [];
             });
-            await db.collections!.studies_collection.findOneAndUpdate({
+            await db.collections.studies_collection.findOneAndUpdate({
                 id: studyId, deleted: null, ontologyTrees: {
                     $not: {
                         $elemMatch: {
@@ -1280,7 +1369,7 @@ export const studyResolvers = {
                     ontologyTrees: ontologyTreeWithId
                 }
             });
-            await db.collections!.studies_collection.findOneAndUpdate({ id: studyId, deleted: null, ontologyTrees: { $elemMatch: { name: ontologyTreeWithId.name, dataVersion: null } } }, {
+            await db.collections.studies_collection.findOneAndUpdate({ id: studyId, deleted: null, ontologyTrees: { $elemMatch: { name: ontologyTreeWithId.name, dataVersion: null } } }, {
                 $set: {
                     'ontologyTrees.$.routes': ontologyTreeWithId.routes,
                     'ontologyTrees.$.dataVersion': null,
@@ -1290,6 +1379,9 @@ export const studyResolvers = {
             return ontologyTreeWithId as IOntologyTree;
         },
         deleteOntologyTree: async (__unused__parent: Record<string, unknown>, { studyId, treeName }: { studyId: string, treeName: string }, context: any): Promise<IGenericResponse> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             /* check study exists */
             await studyCore.findOneStudy_throwErrorIfNotExist(studyId);
 
@@ -1304,7 +1396,7 @@ export const studyResolvers = {
             );
             if (!hasPermission) { throw new GraphQLError(errorCodes.NO_PERMISSION_ERROR); }
 
-            const resultAdd = await db.collections!.studies_collection.findOneAndUpdate({
+            const resultAdd = await db.collections.studies_collection.findOneAndUpdate({
                 id: studyId, deleted: null, ontologyTrees: {
                     $not: {
                         $elemMatch: {
@@ -1323,7 +1415,7 @@ export const studyResolvers = {
                     }
                 }
             });
-            const resultUpdate = await db.collections!.studies_collection.findOneAndUpdate({
+            const resultUpdate = await db.collections.studies_collection.findOneAndUpdate({
                 id: studyId, deleted: null, ontologyTrees: { $elemMatch: { name: treeName, dataVersion: null } }
             }, {
                 $set: {
@@ -1339,6 +1431,9 @@ export const studyResolvers = {
 
         },
         createProject: async (__unused__parent: Record<string, unknown>, { studyId, projectName }: { studyId: string, projectName: string }, context: any): Promise<IProject> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
 
             /* check privileges */
@@ -1359,6 +1454,9 @@ export const studyResolvers = {
             return project;
         },
         deleteProject: async (__unused__parent: Record<string, unknown>, { projectId }: { projectId: string }, context: any): Promise<IGenericResponse> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
 
             const project = await studyCore.findOneProject_throwErrorIfNotExist(projectId);
@@ -1378,6 +1476,9 @@ export const studyResolvers = {
             return makeGenericReponse(projectId);
         },
         deleteStudy: async (__unused__parent: Record<string, unknown>, { studyId }: { studyId: string }, context: any): Promise<IGenericResponse> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
 
             /* check privileges */
@@ -1385,7 +1486,7 @@ export const studyResolvers = {
                 throw new GraphQLError(errorCodes.NO_PERMISSION_ERROR);
             }
 
-            const study = await db.collections!.studies_collection.findOne({ id: studyId, deleted: null });
+            const study = await db.collections.studies_collection.findOne({ id: studyId, deleted: null });
 
             if (study) {
                 /* delete study */
@@ -1397,6 +1498,9 @@ export const studyResolvers = {
             return makeGenericReponse(studyId);
         },
         setDataversionAsCurrent: async (__unused__parent: Record<string, unknown>, { studyId, dataVersionId }: { studyId: string, dataVersionId: string }, context: any): Promise<IStudy> => {
+            if (!db.collections) {
+                throw new GraphQLError(errorCodes.DATABASE_ERROR);
+            }
             const requester: IUser = context.req.user;
 
             /* check privileges */
@@ -1424,13 +1528,13 @@ export const studyResolvers = {
             // };
 
             /* add this to the database */
-            // const result = await db.collections!.studies_collection.findOneAndUpdate({ id: studyId, deleted: null }, {
+            // const result = await db.collections.studies_collection.findOneAndUpdate({ id: studyId, deleted: null }, {
             //     $push: { dataVersions: newDataVersion }, $inc: { currentDataVersion: 1 }
             // }, { returnDocument: 'after' });
 
             /* update the currentversion field in database */
             const versionIdsList = study.dataVersions.map((el) => el.id);
-            const result = await db.collections!.studies_collection.findOneAndUpdate({ id: studyId, deleted: null }, {
+            const result = await db.collections.studies_collection.findOneAndUpdate({ id: studyId, deleted: null }, {
                 $set: { currentDataVersion: versionIdsList.indexOf(dataVersionId) }
             }, {
                 returnDocument: 'after'
@@ -1441,9 +1545,6 @@ export const studyResolvers = {
             } else {
                 throw new GraphQLError(errorCodes.DATABASE_ERROR);
             }
-
-
-
         }
     },
     Subscription: {}

--- a/packages/itmat-interface/src/index.ts
+++ b/packages/itmat-interface/src/index.ts
@@ -29,7 +29,7 @@ function serverStart() {
                 socket.setKeepAlive(true);
                 socket.setNoDelay(true);
                 socket.setTimeout(0);
-                (socket as any).timeout = 0;
+                socket.timeout = 0;
                 interfaceSockets.push(socket);
             })
             .on('error', (error) => {
@@ -78,7 +78,7 @@ function serverSpinning() {
 
 serverSpinning();
 
-declare const module: any;
+declare const module;
 if (module.hot) {
     module.hot.accept('./index', serverSpinning);
     module.hot.accept('./interfaceRunner', serverSpinning);
@@ -90,10 +90,10 @@ async function emailNotification() {
     const now = Date.now().valueOf();
     const threshold = now + 7 * 24 * 60 * 60 * 1000;
     // update info if not set before
-    await db.collections!.users_collection.updateMany({ deleted: null, emailNotificationsStatus: null }, {
+    await db.collections.users_collection.updateMany({ deleted: null, emailNotificationsStatus: null }, {
         $set: { emailNotificationsStatus: { expiringNotification: false } }
     });
-    const users = await db.collections!.users_collection.find<IUser>({
+    const users = await db.collections.users_collection.find<IUser>({
         'expiredAt': {
             $lte: threshold,
             $gt: now
@@ -123,7 +123,7 @@ async function emailNotification() {
                 </p>
             `
         });
-        await db.collections!.users_collection.findOneAndUpdate({ id: user.id }, {
+        await db.collections.users_collection.findOneAndUpdate({ id: user.id }, {
             $set: { emailNotificationsStatus: { expiringNotification: true } }
         });
     }

--- a/packages/itmat-interface/src/interfaceRunner.ts
+++ b/packages/itmat-interface/src/interfaceRunner.ts
@@ -26,7 +26,7 @@ class ITMATInterfaceRunner extends Runner {
                 .then(() => objStore.connect(this.config.objectStore))
                 .then(async () => {
 
-                    const jobChangestream = db.collections!.jobs_collection.watch([
+                    const jobChangestream = db.collections.jobs_collection.watch([
                         { $match: { operationType: { $in: ['update', 'insert'] } } }
                     ], { fullDocument: 'updateLookup' });
                     jobChangestream.on('change', data => {

--- a/packages/itmat-interface/src/log/logPlugin.ts
+++ b/packages/itmat-interface/src/log/logPlugin.ts
@@ -1,6 +1,8 @@
 import { db } from '../database/database';
 import { v4 as uuid } from 'uuid';
 import { LOG_TYPE, LOG_ACTION, LOG_STATUS, USER_AGENT, userTypes } from '@itmat-broker/itmat-types';
+import { GraphQLError } from 'graphql';
+import { errorCodes } from '../graphql/errors';
 
 // only requests in white list will be recorded
 export const logActionRecordWhiteList = Object.keys(LOG_ACTION);
@@ -10,7 +12,10 @@ export const logActionShowWhiteList = Object.keys(LOG_ACTION);
 
 export class LogPlugin {
     public async serverWillStartLogPlugin(): Promise<null> {
-        await db.collections!.log_collection.insertOne({
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
+        await db.collections.log_collection.insertOne({
             id: uuid(),
             requesterName: userTypes.SYSTEM,
             requesterType: userTypes.SYSTEM,
@@ -26,19 +31,22 @@ export class LogPlugin {
     }
 
     public async requestDidStartLogPlugin(requestContext: any): Promise<null> {
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
         if (!logActionRecordWhiteList.includes(requestContext.operationName)) {
             return null;
         }
         if ((LOG_ACTION as any)[requestContext.operationName] === undefined || (LOG_ACTION as any)[requestContext.operationName] === null) {
             return null;
         }
-        await db.collections!.log_collection.insertOne({
+        await db.collections.log_collection.insertOne({
             id: uuid(),
             requesterName: requestContext.contextValue?.req?.user?.username ?? 'NA',
             requesterType: requestContext.contextValue?.req?.user?.type ?? userTypes.SYSTEM,
             userAgent: (requestContext.contextValue.req.headers['user-agent'] as string)?.startsWith('Mozilla') ? USER_AGENT.MOZILLA : USER_AGENT.OTHER,
             logType: LOG_TYPE.REQUEST_LOG,
-            actionType: (LOG_ACTION as any)[requestContext.operationName],
+            actionType: LOG_ACTION[requestContext.operationName as keyof typeof LOG_ACTION],
             actionData: JSON.stringify(ignoreFieldsHelper(requestContext.request.variables, requestContext.operationName)),
             time: Date.now(),
             status: requestContext.errors === undefined ? LOG_STATUS.SUCCESS : LOG_STATUS.FAIL,

--- a/packages/itmat-interface/src/server/router.ts
+++ b/packages/itmat-interface/src/server/router.ts
@@ -91,7 +91,7 @@ export class Router {
             requestTimeout: 0,
             headersTimeout: 0,
             noDelay: true
-        } as any, this.app);
+        }, this.app);
 
         this.server.timeout = 0;
         this.server.headersTimeout = 0;
@@ -101,7 +101,7 @@ export class Router {
             socket.setKeepAlive(true);
             socket.setNoDelay(true);
             socket.setTimeout(0);
-            (socket as any).timeout = 0;
+            socket.timeout = 0;
         });
     }
 
@@ -141,7 +141,7 @@ export class Router {
                             async executionDidStart(requestContext) {
                                 const operation = requestContext.operationName;
                                 const actionData = requestContext.request.variables;
-                                (requestContext as any).request.variables = spaceFixing(operation as any, actionData);
+                                requestContext.request.variables = spaceFixing(operation, actionData);
                             },
                             async willSendResponse(requestContext) {
                                 logPlugin.requestDidStartLogPlugin(requestContext);
@@ -232,10 +232,10 @@ export class Router {
                         // get the decoded payload ignoring signature, no symmetric secret or asymmetric key needed
                         const decodedPayload = jwt.decode(token);
                         // obtain the public-key of the robot user in the JWT payload
-                        const pubkey = (decodedPayload as any).publicKey;
+                        const pubkey = decodedPayload.publicKey;
 
                         // verify the JWT
-                        jwt.verify(token, pubkey, function (error: any) {
+                        jwt.verify(token, pubkey, function (error) {
                             if (error) {
                                 throw new GraphQLError('JWT verification failed. ' + error, { extensions: { code: ApolloServerErrorCode.BAD_USER_INPUT, error } });
                             }

--- a/packages/itmat-interface/src/utils/configManager.ts
+++ b/packages/itmat-interface/src/utils/configManager.ts
@@ -10,7 +10,7 @@ export interface IConfiguration extends IServerConfig {
     appName: string;
     database: IDatabaseBaseConfig;
     objectStore: IObjectStoreConfig;
-    nodemailer: any;
+    nodemailer;
     aesSecret: string;
     sessionsSecret: string;
     adminEmail: string;

--- a/packages/itmat-interface/src/utils/pubkeycrypto.ts
+++ b/packages/itmat-interface/src/utils/pubkeycrypto.ts
@@ -15,7 +15,7 @@ export function rsasigner(privateKey: string, message: string, scheme = 'RSA-SHA
         signer.end();
         return signature;
     }
-    catch (err: any) {
+    catch (err) {
         return err;
     }
 }
@@ -42,7 +42,7 @@ export function reGenPkfromSk(privateKey: string, passphrase = 'idea-fast'): str
         });
         return reGenPk.toString('base64');
     }
-    catch (err: any) {
+    catch (err) {
         return err;
     }
 }

--- a/packages/itmat-interface/src/utils/regrex.ts
+++ b/packages/itmat-interface/src/utils/regrex.ts
@@ -1,3 +1,4 @@
+import { VariableValues } from 'apollo-server-types';
 // whether passwords can contain spaces remains to be determined by the resolver functions
 // the format doesnt allow extra spaces for any kinds of names, but whether spaces are not allowed is
 // determined by the resolver functions
@@ -11,7 +12,7 @@ const omitOperationsAndFields = {
 // By default, only one space is allowed between adjacent letters
 // this function only format the parameters, other requirement, such as duplicate check
 // relies on the resolver functions
-export function spaceFixing(operation: keyof typeof omitOperationsAndFields, actionData: any) {
+export function spaceFixing(operation: keyof typeof omitOperationsAndFields, actionData?: VariableValues) {
     if (Object.keys(omitOperationsAndFields).includes(operation)) {
         if (!omitOperationsAndFields[operation].length) {
             return actionData;
@@ -21,7 +22,7 @@ export function spaceFixing(operation: keyof typeof omitOperationsAndFields, act
     return actionData;
 }
 
-export function recursiveFix(operation: keyof typeof omitOperationsAndFields, obj: any): void {
+export function recursiveFix(operation: keyof typeof omitOperationsAndFields, obj: Record<string, any>): void {
     if (obj !== null && obj !== undefined) {
         // keep it original if it is a promise
         if (obj instanceof Promise) {

--- a/packages/itmat-interface/src/utils/userLoginUtils.ts
+++ b/packages/itmat-interface/src/utils/userLoginUtils.ts
@@ -1,5 +1,7 @@
 import { IUser, IUserWithoutToken } from '@itmat-broker/itmat-types';
 import { db } from '../database/database';
+import { GraphQLError } from 'graphql';
+import { errorCodes } from '../graphql/errors';
 
 export class UserLoginUtils {
     constructor() {
@@ -7,17 +9,20 @@ export class UserLoginUtils {
         this.deserialiseUser = this.deserialiseUser.bind(this);
     }
 
-    public serialiseUser(user: Express.User, done: (__unused__err: any, __unused__id?: any) => void): void {
+    public serialiseUser(user: Express.User, done: (__unused__err, __unused__id?) => void): void {
         done(null, (user as IUser).username);
     }
 
-    public async deserialiseUser(username: string, done: (__unused__err: any, __unused__id?: any) => void): Promise<void> {
+    public async deserialiseUser(username: string, done: (__unused__err, __unused__id?) => void): Promise<void> {
         const user = await this._getUser(username);
         done(null, user);
     }
 
     private async _getUser(username: string): Promise<IUserWithoutToken | null> {
-        return await db.collections!.users_collection.findOne<IUserWithoutToken>({ deleted: null, username }, { projection: { _id: 0, deleted: 0, password: 0 } })!;
+        if (!db.collections) {
+            throw new GraphQLError(errorCodes.DATABASE_ERROR);
+        }
+        return await db.collections.users_collection.findOne<IUserWithoutToken>({ deleted: null, username }, { projection: { _id: 0, deleted: 0, password: 0 } })!;
     }
 }
 

--- a/packages/itmat-interface/test/serverTests/file.test.ts
+++ b/packages/itmat-interface/test/serverTests/file.test.ts
@@ -64,7 +64,7 @@ if (global.hasMinio) {
     }, 10000);
 
     describe('FILE API', () => {
-        let adminId: any;
+        let adminId;
 
         beforeAll(async () => {
             /* setup: first retrieve the generated user id */
@@ -75,11 +75,11 @@ if (global.hasMinio) {
         describe('UPLOAD AND DOWNLOAD FILE', () => {
             describe('UPLOAD FILE', () => {
                 /* note: a new study is created and a special authorised user for study permissions */
-                let createdStudy: { id: any; };
+                let createdStudy: { id; };
                 let createdStudyClinical;
-                let createdStudyAny: { id: any; };
+                let createdStudyAny: { id; };
                 let authorisedUser: request.SuperTest<request.Test>;
-                let authorisedUserProfile: { id: any; otpSecret: any; username?: string; type?: string; firstname?: string; lastname?: string; password?: string; email?: string; description?: string; emailNotificationsActivated?: boolean; organisation?: string; deleted?: null; };
+                let authorisedUserProfile: { id; otpSecret; username?: string; type?: string; firstname?: string; lastname?: string; password?: string; email?: string; description?: string; emailNotificationsActivated?: boolean; organisation?: string; deleted?: null; };
                 beforeEach(async () => {
                     /* setup: create a study to upload file to */
                     const studyname = uuid();
@@ -477,7 +477,7 @@ if (global.hasMinio) {
             describe('DOWNLOAD FILES', () => {
                 /* note: a new study is created and a non-empty text file is uploaded before each test */
                 let createdStudy;
-                let createdFile: { id: any; };
+                let createdFile: { id; };
                 let authorisedUser: request.SuperTest<request.Test>;
                 let authorisedUserProfile;
 
@@ -661,12 +661,12 @@ if (global.hasMinio) {
 
             describe('DELETE FILES', () => {
                 let createdStudy;
-                let createdFile: { id: any; };
+                let createdFile: { id; };
                 let authorisedUser: request.SuperTest<request.Test>;
                 let authorisedUserProfile;
                 beforeEach(async () => {
                     /* Clear old values */
-                    await db.collections!.roles_collection.deleteMany({});
+                    await db.collections.roles_collection.deleteMany({});
                     /* setup: create a study to upload file to */
                     const studyname = uuid();
                     const createStudyRes = await admin.post('/graphql').send({

--- a/packages/itmat-interface/test/serverTests/job.test.ts
+++ b/packages/itmat-interface/test/serverTests/job.test.ts
@@ -56,11 +56,11 @@ beforeAll(async () => { // eslint-disable-line no-undef
 });
 
 describe('JOB API', () => {
-    let adminId: any;
-    let createdStudy: { id: any; name?: string; createdBy?: string; lastModified?: number; deleted?: null; currentDataVersion?: number; dataVersions?: never[]; };
-    let createdProject: { id: any; name?: string; createdBy?: string; lastModified?: number; studyId?: string; deleted?: null; patientMapping?: Record<string, any>; };
-    let createdQuery: { id: any; requester?: string; queryString?: { date_requested: string; }; studyId?: string; projectId?: string; status?: string; error?: null; cancelled?: boolean; data_requested?: never[]; cohort?: never[][]; new_fields?: never[]; queryResult?: never[]; };
-    let createdFile: { id: any; fileName?: string; studyId?: string; fileSize?: string; description?: string; uploadedBy?: any; uri?: string; deleted?: null; };
+    let adminId;
+    let createdStudy: { id; name?: string; createdBy?: string; lastModified?: number; deleted?: null; currentDataVersion?: number; dataVersions?: never[]; };
+    let createdProject: { id; name?: string; createdBy?: string; lastModified?: number; studyId?: string; deleted?: null; patientMapping?: Record<string, any>; };
+    let createdQuery: { id; requester?: string; queryString?: { date_requested: string; }; studyId?: string; projectId?: string; status?: string; error?: null; cancelled?: boolean; data_requested?: never[]; cohort?: never[][]; new_fields?: never[]; queryResult?: never[]; };
+    let createdFile: { id; fileName?: string; studyId?: string; fileSize?: string; description?: string; uploadedBy?; uri?: string; deleted?: null; };
 
     beforeAll(async () => {
         /* setup: first retrieve the generated user id */

--- a/packages/itmat-interface/test/serverTests/log.test.ts
+++ b/packages/itmat-interface/test/serverTests/log.test.ts
@@ -94,7 +94,7 @@ describe('LOG API', () => {
                 }
             });
             expect(res.status).toBe(200);
-            const findLogInMongo = await db.collections!.log_collection.find({}).toArray();
+            const findLogInMongo = await db.collections.log_collection.find({}).toArray();
             const lastLog = findLogInMongo.pop();
             expect(lastLog).toBeDefined();
             if (!lastLog)
@@ -135,7 +135,7 @@ describe('LOG API', () => {
                 status: LOG_STATUS.SUCCESS,
                 errors: ''
             }];
-            await db.collections!.log_collection.insertMany(logSample);
+            await db.collections.log_collection.insertMany(logSample);
         });
 
         afterAll(async () => {

--- a/packages/itmat-interface/test/serverTests/permission.test.ts
+++ b/packages/itmat-interface/test/serverTests/permission.test.ts
@@ -56,7 +56,7 @@ beforeAll(async () => { // eslint-disable-line no-undef
 });
 
 describe('ROLE API', () => {
-    let adminId: any;
+    let adminId;
 
     beforeAll(async () => {
         /* setup: first retrieve the generated user id */
@@ -65,10 +65,10 @@ describe('ROLE API', () => {
     });
 
     describe('ADDING ROLE', () => {
-        let setupStudy: { id: any; name?: string; createdBy?: any; lastModified?: number; deleted?: null; currentDataVersion?: number; dataVersions?: never[]; };
-        let setupProject: { id: any; studyId?: string; createdBy?: any; patientMapping?: Record<string, any>; name?: string; lastModified?: number; deleted?: null; };
+        let setupStudy: { id; name?: string; createdBy?; lastModified?: number; deleted?: null; currentDataVersion?: number; dataVersions?: never[]; };
+        let setupProject: { id; studyId?: string; createdBy?; patientMapping?: Record<string, any>; name?: string; lastModified?: number; deleted?: null; };
         let authorisedUser: request.SuperTest<request.Test>;
-        let authorisedUserProfile: { otpSecret: any; id: any; username?: string; type?: string; firstname?: string; lastname?: string; password?: string; email?: string; description?: string; emailNotificationsActivated?: boolean; organisation?: string; deleted?: null; };
+        let authorisedUserProfile: { otpSecret; id; username?: string; type?: string; firstname?: string; lastname?: string; password?: string; email?: string; description?: string; emailNotificationsActivated?: boolean; organisation?: string; deleted?: null; };
         beforeEach(async () => {
             const studyName = uuid();
             setupStudy = {
@@ -669,8 +669,8 @@ describe('ROLE API', () => {
 
     describe('EDITING ROLE', () => {
         describe('EDIT STUDY ROLE', () => {
-            let setupStudy: { id: any; name?: string; createdBy?: any; lastModified?: number; deleted?: null; currentDataVersion?: number; dataVersions?: never[]; };
-            let setupRole: { id: any; _id?: any; name: any; studyId: any; projectId?: null; permissions?: never[]; createdBy?: any; users?: never[]; deleted?: null; };
+            let setupStudy: { id; name?: string; createdBy?; lastModified?: number; deleted?: null; currentDataVersion?: number; dataVersions?: never[]; };
+            let setupRole: { id; _id?; name; studyId; projectId?: null; permissions?: never[]; createdBy?; users?: never[]; deleted?: null; };
             let authorisedUser: request.SuperTest<request.Test>;
             let authorisedUserProfile;
             beforeEach(async () => {
@@ -2373,9 +2373,9 @@ describe('ROLE API', () => {
         });
 
         describe('EDIT PROJECT ROLE', () => {
-            let setupStudy: { id: any; name?: string; createdBy?: any; lastModified?: number; deleted?: null; currentDataVersion?: number; dataVersions?: never[]; };
-            let setupProject: { id: any; studyId?: string; createdBy?: any; patientMapping?: Record<string, any>; name?: string; lastModified?: number; deleted?: null; };
-            let setupRole: { id: any; _id?: any; name: any; projectId?: string; studyId?: string; permissions?: never[]; createdBy?: any; users?: never[]; deleted?: null; };
+            let setupStudy: { id; name?: string; createdBy?; lastModified?: number; deleted?: null; currentDataVersion?: number; dataVersions?: never[]; };
+            let setupProject: { id; studyId?: string; createdBy?; patientMapping?: Record<string, any>; name?: string; lastModified?: number; deleted?: null; };
+            let setupRole: { id; _id?; name; projectId?: string; studyId?: string; permissions?: never[]; createdBy?; users?: never[]; deleted?: null; };
             let authorisedUser: request.SuperTest<request.Test>;
             let authorisedUserProfile;
             beforeEach(async () => {
@@ -2959,7 +2959,7 @@ describe('ROLE API', () => {
     describe('DELETING ROLE', () => {
         describe('DELETE STUDY ROLE', () => {
             let setupStudy;
-            let setupRole: { id: any; projectId?: null; studyId?: string; name?: string; permissions?: never[]; createdBy?: any; users?: never[]; deleted?: null; };
+            let setupRole: { id; projectId?: null; studyId?: string; name?: string; permissions?: never[]; createdBy?; users?: never[]; deleted?: null; };
             let authorisedUser: request.SuperTest<request.Test>;
             let authorisedUserProfile;
             beforeEach(async () => {
@@ -3116,7 +3116,7 @@ describe('ROLE API', () => {
         describe('DELETE PROJECT ROLE', () => {
             let setupStudy;
             let setupProject;
-            let setupRole: { id: any; projectId?: string; studyId?: string; name?: string; permissions?: never[]; createdBy?: any; users?: never[]; deleted?: null; };
+            let setupRole: { id; projectId?: string; studyId?: string; name?: string; permissions?: never[]; createdBy?; users?: never[]; deleted?: null; };
             let authorisedUser: request.SuperTest<request.Test>;
             let authorisedUserProfile;
             beforeEach(async () => {

--- a/packages/itmat-interface/test/serverTests/standardization.test.ts
+++ b/packages/itmat-interface/test/serverTests/standardization.test.ts
@@ -80,7 +80,7 @@ beforeAll(async () => { // eslint-disable-line no-undef
 });
 
 describe('STUDY API', () => {
-    let adminId: any;
+    let adminId;
 
     beforeAll(async () => {
         /* setup: first retrieve the generated user id */
@@ -90,7 +90,7 @@ describe('STUDY API', () => {
 
     describe('MINI END-TO-END API TEST, NO UI, NO DATA', () => {
         let createdProject;
-        let createdStudy: { id: any; name: any; };
+        let createdStudy: { id; name; };
         let createdRole_study;
         let createdRole_study_manageProject;
         let createdRole_project;
@@ -755,9 +755,9 @@ describe('STUDY API', () => {
             }
 
             /* delete values in db */
-            await db.collections!.field_dictionary_collection.deleteMany({ studyId: createdStudy.id });
-            await db.collections!.data_collection.deleteMany({ m_studyId: createdStudy.id });
-            await db.collections!.files_collection.deleteMany({ studyId: createdStudy.id });
+            await db.collections.field_dictionary_collection.deleteMany({ studyId: createdStudy.id });
+            await db.collections.data_collection.deleteMany({ m_studyId: createdStudy.id });
+            await db.collections.files_collection.deleteMany({ studyId: createdStudy.id });
 
             /* study user cannot delete study */
             {
@@ -810,9 +810,9 @@ describe('STUDY API', () => {
                 });
 
                 // study data is NOT deleted for audit purposes - unless explicitly requested separately
-                const roles = await db.collections!.roles_collection.find({ studyId: createdStudy.id, deleted: null }).toArray();
-                const projects = await db.collections!.projects_collection.find({ studyId: createdStudy.id, deleted: null }).toArray();
-                const study = await db.collections!.studies_collection.findOne({ id: createdStudy.id, deleted: null });
+                const roles = await db.collections.roles_collection.find({ studyId: createdStudy.id, deleted: null }).toArray();
+                const projects = await db.collections.projects_collection.find({ studyId: createdStudy.id, deleted: null }).toArray();
+                const study = await db.collections.studies_collection.findOne({ id: createdStudy.id, deleted: null });
                 expect(roles).toEqual([]);
                 expect(projects).toEqual([]);
                 expect(study).toBe(null);
@@ -832,8 +832,8 @@ describe('STUDY API', () => {
         });
 
         afterEach(async () => {
-            await db.collections!.standardizations_collection.deleteMany({});
-            await db.collections!.studies_collection.findOneAndUpdate({ id: createdStudy.id, deleted: null }, { $set: { dataVersions: [], currentDataVersion: -1 } });
+            await db.collections.standardizations_collection.deleteMany({});
+            await db.collections.studies_collection.findOneAndUpdate({ id: createdStudy.id, deleted: null }, { $set: { dataVersions: [], currentDataVersion: -1 } });
         });
 
         test('Create standardization (authorised user)', async () => {
@@ -857,7 +857,7 @@ describe('STUDY API', () => {
                     }
                 }
             });
-            const std = await db.collections!.standardizations_collection.findOne({});
+            const std = await db.collections.standardizations_collection.findOne({});
             expect(res.status).toBe(200);
             expect(res.body.errors).toBeUndefined();
             expect(res.body.data.createStandardization).toEqual({
@@ -940,7 +940,7 @@ describe('STUDY API', () => {
                     type: 'fakeType'
                 }
             });
-            const std = await db.collections!.standardizations_collection.findOne({ studyId: createdStudy.id, type: 'fakeType', field: ['$testField'] });
+            const std = await db.collections.standardizations_collection.findOne({ studyId: createdStudy.id, type: 'fakeType', field: ['$testField'] });
             expect(res.status).toBe(200);
             expect(res.body.errors).toBeUndefined();
             expect(res.body.data.getStandardization[0]).toEqual({
@@ -1012,7 +1012,7 @@ describe('STUDY API', () => {
                 }
             });
             // modify the uploadedAt of the second uploading as we use mock
-            await db.collections!.standardizations_collection.findOneAndUpdate({ stdRules: { $elemMatch: { entry: 'fakeEntryNew' } } }, {
+            await db.collections.standardizations_collection.findOneAndUpdate({ stdRules: { $elemMatch: { entry: 'fakeEntryNew' } } }, {
                 $set: {
                     uploadedAt: 1591134065001
                 }
@@ -1096,7 +1096,7 @@ describe('STUDY API', () => {
                     }
                 }
             });
-            const std = await db.collections!.standardizations_collection.findOne({});
+            const std = await db.collections.standardizations_collection.findOne({});
             const res = await authorisedUserStudy.post('/graphql').send({
                 query: print(DELETE_STANDARDIZATION),
                 variables: {
@@ -1439,7 +1439,7 @@ describe('STUDY API', () => {
             });
             expect(res.status).toBe(200);
             expect(res.body.errors).toBeUndefined();
-            expect(res.body.data.getDataRecords.data.QS.sort((a: { entry_reserved: string; entry_inc: number; }, b: { entry_reserved: any; entry_inc: number; }) => {
+            expect(res.body.data.getDataRecords.data.QS.sort((a: { entry_reserved: string; entry_inc: number; }, b: { entry_reserved; entry_inc: number; }) => {
                 return a.entry_reserved !== b.entry_reserved ? a.entry_reserved.localeCompare(b.entry_reserved)
                     : a.entry_inc - b.entry_inc;
             })).toEqual([
@@ -1508,7 +1508,7 @@ describe('STUDY API', () => {
                     visit: '2'
                 }
             ]);
-            expect(res.body.data.getDataRecords.data.DM.sort((a: { entry_reserved: string; entry_inc: number; }, b: { entry_reserved: any; entry_inc: number; }) => {
+            expect(res.body.data.getDataRecords.data.DM.sort((a: { entry_reserved: string; entry_inc: number; }, b: { entry_reserved; entry_inc: number; }) => {
                 return a.entry_reserved !== b.entry_reserved ? a.entry_reserved.localeCompare(b.entry_reserved)
                     : a.entry_inc - b.entry_inc;
             }).map(el => el.entry_reserved)).toEqual(['GR6R4AR', 'I7N3G6G']);

--- a/packages/itmat-interface/test/serverTests/study.test.ts
+++ b/packages/itmat-interface/test/serverTests/study.test.ts
@@ -108,7 +108,7 @@ if (global.hasMinio) {
     });
 
     describe('STUDY API', () => {
-        let adminId: any;
+        let adminId;
 
         beforeAll(async () => {
             /* setup: first retrieve the generated user id */
@@ -456,8 +456,8 @@ if (global.hasMinio) {
 
         describe('MANIPULATING PROJECTS EXISTENCE', () => {
             let testCounter = 0;
-            let setupStudy: { id: any; name?: string; createdBy?: string; lastModified?: number; deleted?: null; currentDataVersion?: number; dataVersions?: { id: string; contentId: string; version: string; tag: string; updateDate: string; }[]; };
-            let setupProject: { id: any; studyId?: string; createdBy?: string; name?: string; patientMapping?: { patient001: string; }; lastModified?: number; deleted?: null; };
+            let setupStudy: { id; name?: string; createdBy?: string; lastModified?: number; deleted?: null; currentDataVersion?: number; dataVersions?: { id: string; contentId: string; version: string; tag: string; updateDate: string; }[]; };
+            let setupProject: { id; studyId?: string; createdBy?: string; name?: string; patientMapping?: { patient001: string; }; lastModified?: number; deleted?: null; };
             beforeEach(async () => {
                 testCounter++;
                 /* setup: creating a study */
@@ -750,16 +750,16 @@ if (global.hasMinio) {
         });
 
         describe('MINI END-TO-END API TEST, NO UI, NO DATA', () => {
-            let createdProject: { id: any; name: any; patientMapping: { mock_patient1: any; mock_patient2: any; }; };
-            let createdStudy: { id: any; name: any; };
-            let createdRole_study: { _id: any; id: any; name: any; };
-            let createdRole_study_manageProject: { _id: any; id: any; name: any; };
-            let createdRole_study_self_access: { _id: any; id: any; name: any; };
-            let createdRole_project: { _id: any; id: any; name: any; };
-            let createdUserAuthorised: { id: any; firstname: any; lastname: any; username: string; otpSecret: string; };  // profile
-            let createdUserAuthorisedStudy: { id: any; firstname: any; lastname: any; username: string; otpSecret: string; };  // profile
-            let createdUserAuthorisedStudyManageProjects: { id: any; firstname: any; lastname: any; username: string; otpSecret: string; };  // profile
-            let createdUserAuthorisedToOneOrg: { id: any; firstname: any; lastname: any; username: string; otpSecret: string; }; // profile
+            let createdProject: { id; name; patientMapping: { mock_patient1; mock_patient2; }; };
+            let createdStudy: { id; name; };
+            let createdRole_study: { _id; id; name; };
+            let createdRole_study_manageProject: { _id; id; name; };
+            let createdRole_study_self_access: { _id; id; name; };
+            let createdRole_project: { _id; id; name; };
+            let createdUserAuthorised: { id; firstname; lastname; username: string; otpSecret: string; };  // profile
+            let createdUserAuthorisedStudy: { id; firstname; lastname; username: string; otpSecret: string; };  // profile
+            let createdUserAuthorisedStudyManageProjects: { id; firstname; lastname; username: string; otpSecret: string; };  // profile
+            let createdUserAuthorisedToOneOrg: { id; firstname; lastname; username: string; otpSecret: string; }; // profile
             let authorisedUser: request.SuperTest<request.Test>; // client
             let authorisedUserStudy: request.SuperTest<request.Test>; // client
             let authorisedUserStudyManageProject: request.SuperTest<request.Test>; // client
@@ -904,7 +904,7 @@ if (global.hasMinio) {
                             hash: '4ae25be36354ee0aec8dc8deac3f279d2e9d6415361da996cf57eb6142cfb1a3'
                         }
                     ];
-                    await db.collections!.studies_collection.updateOne({ id: createdStudy.id }, {
+                    await db.collections.studies_collection.updateOne({ id: createdStudy.id }, {
                         $push: { dataVersions: mockDataVersion },
                         $inc: { currentDataVersion: 1 },
                         $set: {
@@ -940,9 +940,9 @@ if (global.hasMinio) {
                             }]
                         }
                     });
-                    await db.collections!.data_collection.insertMany(mockData);
-                    await db.collections!.field_dictionary_collection.insertMany(mockFields);
-                    await db.collections!.files_collection.insertMany(mockFiles);
+                    await db.collections.data_collection.insertMany(mockData);
+                    await db.collections.field_dictionary_collection.insertMany(mockFields);
+                    await db.collections.files_collection.insertMany(mockFiles);
                 }
 
                 /* 2. create projects for the study */
@@ -1770,9 +1770,9 @@ if (global.hasMinio) {
                 }
 
                 /* delete values in db */
-                await db.collections!.field_dictionary_collection.deleteMany({ studyId: createdStudy.id });
-                await db.collections!.data_collection.deleteMany({ m_studyId: createdStudy.id });
-                await db.collections!.files_collection.deleteMany({ studyId: createdStudy.id });
+                await db.collections.field_dictionary_collection.deleteMany({ studyId: createdStudy.id });
+                await db.collections.data_collection.deleteMany({ m_studyId: createdStudy.id });
+                await db.collections.files_collection.deleteMany({ studyId: createdStudy.id });
 
                 /* study user cannot delete study */
                 {
@@ -1825,9 +1825,9 @@ if (global.hasMinio) {
                     });
 
                     // study data is NOT deleted for audit purposes - unless explicitly requested separately
-                    const roles = await db.collections!.roles_collection.find({ studyId: createdStudy.id, deleted: null }).toArray();
-                    const projects = await db.collections!.projects_collection.find({ studyId: createdStudy.id, deleted: null }).toArray();
-                    const study = await db.collections!.studies_collection.findOne({ id: createdStudy.id, deleted: null });
+                    const roles = await db.collections.roles_collection.find({ studyId: createdStudy.id, deleted: null }).toArray();
+                    const projects = await db.collections.projects_collection.find({ studyId: createdStudy.id, deleted: null }).toArray();
+                    const study = await db.collections.studies_collection.findOne({ id: createdStudy.id, deleted: null });
                     expect(roles).toEqual([]);
                     expect(projects).toEqual([]);
                     expect(study).toBe(null);
@@ -2222,7 +2222,7 @@ if (global.hasMinio) {
                 });
                 expect(res.status).toBe(200);
                 expect(res.body.errors).toBeUndefined();
-                expect(res.body.data.getStudyFields.sort((a: { id: string; }, b: { id: any; }) => a.id.localeCompare(b.id))).toEqual([ // as the api will sort the results, the order is changed
+                expect(res.body.data.getStudyFields.sort((a: { id: string; }, b: { id; }) => a.id.localeCompare(b.id))).toEqual([ // as the api will sort the results, the order is changed
                     {
                         id: 'mockfield2',
                         studyId: createdStudy.id,
@@ -2276,7 +2276,7 @@ if (global.hasMinio) {
                 });
                 expect(res.status).toBe(200);
                 expect(res.body.errors).toBeUndefined();
-                expect(res.body.data.getStudyFields.sort((a: { id: string; }, b: { id: any; }) => a.id.localeCompare(b.id))).toEqual([ // as the api will sort the results, the order is changed
+                expect(res.body.data.getStudyFields.sort((a: { id: string; }, b: { id; }) => a.id.localeCompare(b.id))).toEqual([ // as the api will sort the results, the order is changed
                     {
                         id: 'mockfield1',
                         studyId: createdStudy.id,
@@ -2326,7 +2326,7 @@ if (global.hasMinio) {
 
             test('Get study fields, with unversioned fields', async () => {
                 // delete an exisiting field and add a new field
-                await db.collections!.field_dictionary_collection.insertOne({
+                await db.collections.field_dictionary_collection.insertOne({
                     id: 'mockfield2_deleted',
                     studyId: createdStudy.id,
                     fieldId: '32',
@@ -2341,7 +2341,7 @@ if (global.hasMinio) {
                     dataVersion: null
                 });
 
-                await db.collections!.field_dictionary_collection.insertOne({
+                await db.collections.field_dictionary_collection.insertOne({
                     id: 'mockfield3',
                     studyId: createdStudy.id,
                     fieldId: '33',
@@ -2378,7 +2378,7 @@ if (global.hasMinio) {
                 });
                 expect(res2.status).toBe(200);
                 expect(res2.body.errors).toBeUndefined();
-                expect(res2.body.data.getStudyFields.sort((a: { id: string; }, b: { id: any; }) => a.id.localeCompare(b.id))).toEqual([ // as the api will sort the results, the order is changed
+                expect(res2.body.data.getStudyFields.sort((a: { id: string; }, b: { id; }) => a.id.localeCompare(b.id))).toEqual([ // as the api will sort the results, the order is changed
                     {
                         id: 'mockfield2',
                         studyId: createdStudy.id,
@@ -2411,12 +2411,12 @@ if (global.hasMinio) {
                     }
                 ].sort((a, b) => a.id.localeCompare(b.id)));
                 // clear database
-                await db.collections!.field_dictionary_collection.deleteMany({ dataVersion: null });
+                await db.collections.field_dictionary_collection.deleteMany({ dataVersion: null });
             });
 
             test('Set a previous study dataversion as current (admin)', async () => {
                 /* setup: add an extra dataversion */
-                await db.collections!.studies_collection.updateOne({ id: createdStudy.id }, { $push: { dataVersions: newMockDataVersion }, $inc: { currentDataVersion: 1 } });
+                await db.collections.studies_collection.updateOne({ id: createdStudy.id }, { $push: { dataVersions: newMockDataVersion }, $inc: { currentDataVersion: 1 } });
                 const res = await admin.post('/graphql').send({
                     query: print(SET_DATAVERSION_AS_CURRENT),
                     variables: {
@@ -2426,7 +2426,7 @@ if (global.hasMinio) {
                 });
                 expect(res.status).toBe(200);
                 expect(res.body.errors).toBeUndefined();
-                const study = await db.collections!.studies_collection.findOne<IStudy>({ id: createdStudy.id }, { projection: { dataVersions: 1 } });
+                const study = await db.collections.studies_collection.findOne<IStudy>({ id: createdStudy.id }, { projection: { dataVersions: 1 } });
                 expect(study).toBeDefined();
                 expect(res.body.data.setDataversionAsCurrent).toEqual({
                     id: createdStudy.id,
@@ -2444,7 +2444,7 @@ if (global.hasMinio) {
 
             test('Set a previous study dataversion as current (user without privilege) (should fail)', async () => {
                 /* setup: add an extra dataversion */
-                await db.collections!.studies_collection.updateOne({ id: createdStudy.id }, { $push: { dataVersions: newMockDataVersion }, $inc: { currentDataVersion: 1 } });
+                await db.collections.studies_collection.updateOne({ id: createdStudy.id }, { $push: { dataVersions: newMockDataVersion }, $inc: { currentDataVersion: 1 } });
 
                 const res = await user.post('/graphql').send({
                     query: print(SET_DATAVERSION_AS_CURRENT),
@@ -2464,7 +2464,7 @@ if (global.hasMinio) {
 
             test('Set a previous study dataversion as current (user with project privilege) (should fail)', async () => {
                 /* setup: add an extra dataversion */
-                await db.collections!.studies_collection.updateOne({ id: createdStudy.id }, { $push: { dataVersions: newMockDataVersion }, $inc: { currentDataVersion: 1 } });
+                await db.collections.studies_collection.updateOne({ id: createdStudy.id }, { $push: { dataVersions: newMockDataVersion }, $inc: { currentDataVersion: 1 } });
 
                 const res = await authorisedUser.post('/graphql').send({
                     query: print(SET_DATAVERSION_AS_CURRENT),
@@ -2484,7 +2484,7 @@ if (global.hasMinio) {
 
             test('Set a previous study dataversion as current (user with study read-only privilege) (should fail)', async () => {
                 /* setup: add an extra dataversion */
-                await db.collections!.studies_collection.updateOne({ id: createdStudy.id }, { $push: { dataVersions: newMockDataVersion }, $inc: { currentDataVersion: 1 } });
+                await db.collections.studies_collection.updateOne({ id: createdStudy.id }, { $push: { dataVersions: newMockDataVersion }, $inc: { currentDataVersion: 1 } });
 
                 const res = await authorisedUserStudy.post('/graphql').send({
                     query: print(SET_DATAVERSION_AS_CURRENT),
@@ -2504,7 +2504,7 @@ if (global.hasMinio) {
 
             test('Set a previous study dataversion as current (user with study "manage project" privilege)', async () => {
                 /* setup: add an extra dataversion */
-                await db.collections!.studies_collection.updateOne({ id: createdStudy.id }, { $push: { dataVersions: newMockDataVersion }, $inc: { currentDataVersion: 1 } });
+                await db.collections.studies_collection.updateOne({ id: createdStudy.id }, { $push: { dataVersions: newMockDataVersion }, $inc: { currentDataVersion: 1 } });
 
                 const res = await authorisedUserStudyManageProject.post('/graphql').send({
                     query: print(SET_DATAVERSION_AS_CURRENT),
@@ -2541,10 +2541,10 @@ if (global.hasMinio) {
                     createdAt: 1591134065000,
                     expiredAt: 1991134065000
                 };
-                await db.collections!.users_collection.insertOne(userDataCurator);
+                await db.collections.users_collection.insertOne(userDataCurator);
 
                 /* setup: create a new role with data management */
-                const roleDataCurator: any = {
+                const roleDataCurator = {
                     id: uuid(),
                     studyId: createdStudy.id,
                     name: 'Data Manager',
@@ -2569,14 +2569,14 @@ if (global.hasMinio) {
                     createdBy: adminId,
                     deleted: null
                 };
-                await db.collections!.roles_collection.insertOne(roleDataCurator);
+                await db.collections.roles_collection.insertOne(roleDataCurator);
 
                 /* setup: connect user */
                 const dataCurator = request.agent(app);
                 await connectAgent(dataCurator, userDataCurator.username, 'admin', userDataCurator.otpSecret);
 
                 /* setup: add an extra dataversion */
-                await db.collections!.studies_collection.updateOne({ id: createdStudy.id }, { $push: { dataVersions: newMockDataVersion }, $inc: { currentDataVersion: 1 } });
+                await db.collections.studies_collection.updateOne({ id: createdStudy.id }, { $push: { dataVersions: newMockDataVersion }, $inc: { currentDataVersion: 1 } });
 
                 /* test */
                 const res = await dataCurator.post('/graphql').send({
@@ -2595,12 +2595,12 @@ if (global.hasMinio) {
                     .updateOne({ id: createdStudy.id }, { $set: { dataVersions: [mockDataVersion], currentDataVersion: 0 } });
 
                 /* cleanup: delete user and role */
-                await db.collections!.users_collection.deleteOne({ id: userDataCurator.id });
-                await db.collections!.roles_collection.deleteOne({ id: roleDataCurator.id });
+                await db.collections.users_collection.deleteOne({ id: userDataCurator.id });
+                await db.collections.roles_collection.deleteOne({ id: roleDataCurator.id });
             });
 
             test('Create New fields (admin)', async () => {
-                await db.collections!.field_dictionary_collection.deleteMany({ dataVersion: null });
+                await db.collections.field_dictionary_collection.deleteMany({ dataVersion: null });
                 const res = await admin.post('/graphql').send({
                     query: print(CREATE_NEW_FIELD),
                     variables: {
@@ -2637,7 +2637,7 @@ if (global.hasMinio) {
                     { successful: true, code: null, id: null, description: 'Field 8-newField8 is created successfully.' },
                     { successful: true, code: null, id: null, description: 'Field 9-newField9 is created successfully.' }
                 ]);
-                const fieldsInDb = await db.collections!.field_dictionary_collection.find({ studyId: createdStudy.id, dataVersion: null }).toArray();
+                const fieldsInDb = await db.collections.field_dictionary_collection.find({ studyId: createdStudy.id, dataVersion: null }).toArray();
                 expect(fieldsInDb).toHaveLength(2);
             });
 
@@ -2747,11 +2747,11 @@ if (global.hasMinio) {
                 expect(res.status).toBe(200);
                 expect(res.body.errors).toBeUndefined();
                 expect(res.body.data.deleteField.fieldId).toBe('8');
-                const fieldsInDb = await db.collections!.field_dictionary_collection.find({ studyId: createdStudy.id, dateDeleted: { $ne: null } }).toArray();
+                const fieldsInDb = await db.collections.field_dictionary_collection.find({ studyId: createdStudy.id, dateDeleted: { $ne: null } }).toArray();
                 expect(fieldsInDb).toHaveLength(1);
                 expect(fieldsInDb[0].fieldId).toBe('8');
                 // clear database
-                await db.collections!.field_dictionary_collection.deleteMany({ studyId: createdStudy.id, fieldId: { $in: ['8', '9'] } });
+                await db.collections.field_dictionary_collection.deleteMany({ studyId: createdStudy.id, fieldId: { $in: ['8', '9'] } });
             });
 
             test('Delete a versioned field (admin)', async () => {
@@ -2799,19 +2799,19 @@ if (global.hasMinio) {
                 expect(res.status).toBe(200);
                 expect(res.body.errors).toBeUndefined();
                 expect(res.body.data.deleteField.fieldId).toBe('8');
-                const fieldsInDb = await db.collections!.field_dictionary_collection.find({ studyId: createdStudy.id, fieldId: '8' }).toArray();
+                const fieldsInDb = await db.collections.field_dictionary_collection.find({ studyId: createdStudy.id, fieldId: '8' }).toArray();
                 expect(fieldsInDb).toHaveLength(2);
                 expect(fieldsInDb[0].fieldId).toBe('8');
                 expect(fieldsInDb[1].fieldId).toBe('8');
                 expect(fieldsInDb[1].dateDeleted).not.toBe(null);
                 // clear database
-                await db.collections!.field_dictionary_collection.deleteMany({ studyId: createdStudy.id, fieldId: { $in: ['8', '9'] } });
+                await db.collections.field_dictionary_collection.deleteMany({ studyId: createdStudy.id, fieldId: { $in: ['8', '9'] } });
             });
         });
 
         describe('UPLOAD/DELETE DATA RECORDS DIRECTLY VIA API', () => {
-            let createdStudy: { id: any; name: any; };
-            let createdProject: { id: any; name: any; studyId: any; };
+            let createdStudy: { id; name; };
+            let createdProject: { id; name; studyId; };
             let createdRole_study_accessData;
             let createdRole_project;
             let createdUserAuthorisedProject;  // profile
@@ -3153,8 +3153,8 @@ if (global.hasMinio) {
                         metadata: {}
                     }
                 ];
-                await db.collections!.field_dictionary_collection.insertMany(mockFields);
-                await db.collections!.studies_collection.updateOne({ id: createdStudy.id }, {
+                await db.collections.field_dictionary_collection.insertMany(mockFields);
+                await db.collections.studies_collection.updateOne({ id: createdStudy.id }, {
                     $push: { dataVersions: mockDataVersion },
                     $inc: { currentDataVersion: 1 },
                     $set: {
@@ -3401,7 +3401,7 @@ if (global.hasMinio) {
 
                 /* 7. Create an ontologytree */
                 {
-                    await db.collections!.studies_collection.findOneAndUpdate({ id: createdStudy.id }, {
+                    await db.collections.studies_collection.findOneAndUpdate({ id: createdStudy.id }, {
                         $set: {
                             ontologyTrees: [{
                                 id: uuid(),
@@ -3418,7 +3418,7 @@ if (global.hasMinio) {
                 }
                 const study_role_id = `metadata.${'role:'.concat(createdRole_study_accessData?.id)}`;
                 const project_role_id = `metadata.${'role:'.concat(createdRole_project?.id)}`;
-                await db.collections!.field_dictionary_collection.updateMany({ studyId: createdStudy.id }, {
+                await db.collections.field_dictionary_collection.updateMany({ studyId: createdStudy.id }, {
                     $set: {
                         [study_role_id]: true,
                         [project_role_id]: true
@@ -3473,9 +3473,9 @@ if (global.hasMinio) {
                     });
 
                     // study data is NOT deleted for audit purposes - unless explicitly requested separately
-                    const roles = await db.collections!.roles_collection.find({ studyId: createdStudy.id, deleted: null }).toArray();
-                    const projects = await db.collections!.projects_collection.find({ studyId: createdStudy.id, deleted: null }).toArray();
-                    const study = await db.collections!.studies_collection.findOne({ id: createdStudy.id, deleted: null });
+                    const roles = await db.collections.roles_collection.find({ studyId: createdStudy.id, deleted: null }).toArray();
+                    const projects = await db.collections.projects_collection.find({ studyId: createdStudy.id, deleted: null }).toArray();
+                    const study = await db.collections.studies_collection.findOne({ id: createdStudy.id, deleted: null });
                     expect(roles).toEqual([]);
                     expect(projects).toEqual([]);
                     expect(study).toBe(null);
@@ -3493,12 +3493,12 @@ if (global.hasMinio) {
                     expect(res.body.data.getStudy).toBe(null);
                 }
 
-                await db.collections!.field_dictionary_collection.deleteMany({ studyId: createdStudy.id });
+                await db.collections.field_dictionary_collection.deleteMany({ studyId: createdStudy.id });
             });
 
             afterEach(async () => {
-                await db.collections!.data_collection.deleteMany({});
-                await db.collections!.studies_collection.findOneAndUpdate({ id: createdStudy.id }, {
+                await db.collections.data_collection.deleteMany({});
+                await db.collections.studies_collection.findOneAndUpdate({ id: createdStudy.id }, {
                     $set: {
                         dataVersions: [{
                             id: 'mockDataVersionId',
@@ -3508,7 +3508,7 @@ if (global.hasMinio) {
                         }], currentDataVersion: 0
                     }
                 });
-                await db.collections!.field_dictionary_collection.deleteMany({ studyId: createdStudy.id, fieldId: { $nin: ['31', '32'] }, dataVersion: null });
+                await db.collections.field_dictionary_collection.deleteMany({ studyId: createdStudy.id, fieldId: { $nin: ['31', '32'] }, dataVersion: null });
             });
 
             test('Upload a data record to study (authorised user)', async () => {
@@ -3568,7 +3568,7 @@ if (global.hasMinio) {
                     { code: 'CLIENT_MALFORMED_INPUT', description: 'Subject ID I777770 is illegal.', id: null, successful: false }
                 ]);
 
-                const dataInDb = await db.collections!.data_collection.find({ deleted: null }).toArray();
+                const dataInDb = await db.collections.data_collection.find({ deleted: null }).toArray();
                 expect(dataInDb).toHaveLength(3);
             });
 
@@ -3619,8 +3619,8 @@ if (global.hasMinio) {
                 expect(res.status).toBe(200);
                 expect(res.body.errors).toBeUndefined();
                 // check both data collection and file collection
-                const fileFirst = await db.collections!.files_collection.findOne<IFile>({ studyId: createdStudy.id, deleted: null });
-                const dataFirst = await db.collections!.data_collection.findOne<IDataEntry>({ m_studyId: createdStudy.id, m_visitId: '1', m_fieldId: '33' });
+                const fileFirst = await db.collections.files_collection.findOne<IFile>({ studyId: createdStudy.id, deleted: null });
+                const dataFirst = await db.collections.data_collection.findOne<IDataEntry>({ m_studyId: createdStudy.id, m_visitId: '1', m_fieldId: '33' });
                 expect(dataFirst?.metadata?.add[0]).toBe(fileFirst.id);
 
                 // upload again and check whether the old file has been deleted
@@ -3649,8 +3649,8 @@ if (global.hasMinio) {
                     .attach('1', path.join(__dirname, '../filesForTests/I7N3G6G-MMM7N3G6G-20200704-20200721.txt'));
                 expect(resSecond.status).toBe(200);
                 expect(resSecond.body.errors).toBeUndefined();
-                const fileSecond = await db.collections!.files_collection.find<IFile>({ studyId: createdStudy.id, deleted: null }).toArray();
-                const dataSecond = await db.collections!.data_collection.findOne<IDataEntry>({ m_studyId: createdStudy.id, m_visitId: '1', m_fieldId: '33' });
+                const fileSecond = await db.collections.files_collection.find<IFile>({ studyId: createdStudy.id, deleted: null }).toArray();
+                const dataSecond = await db.collections.data_collection.findOne<IDataEntry>({ m_studyId: createdStudy.id, m_visitId: '1', m_fieldId: '33' });
                 expect(fileSecond).toHaveLength(2);
                 expect(dataSecond?.metadata?.add).toEqual([fileSecond[0].id, fileSecond[1].id]);
             });
@@ -3670,11 +3670,11 @@ if (global.hasMinio) {
                 expect(createRes.body.errors).toBeUndefined();
                 expect(createRes.body.data.createNewDataVersion.version).toBe('1');
                 expect(createRes.body.data.createNewDataVersion.tag).toBe('testTag');
-                const studyInDb = await db.collections!.studies_collection.findOne({ id: createdStudy.id });
+                const studyInDb = await db.collections.studies_collection.findOne({ id: createdStudy.id });
                 expect(studyInDb.dataVersions).toHaveLength(2);
                 expect(studyInDb.dataVersions[1].version).toBe('1');
                 expect(studyInDb.dataVersions[1].tag).toBe('testTag');
-                const dataInDb = await db.collections!.data_collection.find({ m_studyId: createdStudy.id, m_versionId: createRes.body.data.createNewDataVersion.id }).toArray();
+                const dataInDb = await db.collections.data_collection.find({ m_studyId: createdStudy.id, m_versionId: createRes.body.data.createNewDataVersion.id }).toArray();
                 expect(dataInDb).toHaveLength(6);
             });
 
@@ -3700,11 +3700,11 @@ if (global.hasMinio) {
                 expect(createRes.body.errors).toBeUndefined();
                 expect(createRes.body.data.createNewDataVersion.version).toBe('1');
                 expect(createRes.body.data.createNewDataVersion.tag).toBe('testTag');
-                const studyInDb = await db.collections!.studies_collection.findOne({ id: createdStudy.id });
+                const studyInDb = await db.collections.studies_collection.findOne({ id: createdStudy.id });
                 expect(studyInDb.dataVersions).toHaveLength(2);
                 expect(studyInDb.dataVersions[1].version).toBe('1');
                 expect(studyInDb.dataVersions[1].tag).toBe('testTag');
-                const fieldIndb = await db.collections!.field_dictionary_collection.find({ studyId: createdStudy.id, dataVersion: { $in: [createRes.body.data.createNewDataVersion.id, 'mockDataVersionId'] } }).toArray();
+                const fieldIndb = await db.collections.field_dictionary_collection.find({ studyId: createdStudy.id, dataVersion: { $in: [createRes.body.data.createNewDataVersion.id, 'mockDataVersionId'] } }).toArray();
                 expect(fieldIndb).toHaveLength(4);
             });
 
@@ -3740,13 +3740,13 @@ if (global.hasMinio) {
                 expect(createRes.body.errors).toBeUndefined();
                 expect(createRes.body.data.createNewDataVersion.version).toBe('1');
                 expect(createRes.body.data.createNewDataVersion.tag).toBe('testTag');
-                const studyInDb = await db.collections!.studies_collection.findOne({ id: createdStudy.id });
+                const studyInDb = await db.collections.studies_collection.findOne({ id: createdStudy.id });
                 expect(studyInDb.dataVersions).toHaveLength(2);
                 expect(studyInDb.dataVersions[1].version).toBe('1');
                 expect(studyInDb.dataVersions[1].tag).toBe('testTag');
-                const dataInDb = await db.collections!.data_collection.find({ m_studyId: createdStudy.id, m_versionId: createRes.body.data.createNewDataVersion.id }).toArray();
+                const dataInDb = await db.collections.data_collection.find({ m_studyId: createdStudy.id, m_versionId: createRes.body.data.createNewDataVersion.id }).toArray();
                 expect(dataInDb).toHaveLength(7);
-                const fieldsInDb = await db.collections!.field_dictionary_collection.find({ studyId: createdStudy.id, dataVersion: { $in: [createRes.body.data.createNewDataVersion.id, 'mockDataVersionId'] } }).toArray();
+                const fieldsInDb = await db.collections.field_dictionary_collection.find({ studyId: createdStudy.id, dataVersion: { $in: [createRes.body.data.createNewDataVersion.id, 'mockDataVersionId'] } }).toArray();
                 expect(fieldsInDb).toHaveLength(4);
             });
 
@@ -3873,7 +3873,7 @@ if (global.hasMinio) {
                     { successful: true, id: null, code: null, description: 'SubjectId-I7N3G6G:visitId-2:fieldId-32 is deleted.' },
                     { successful: true, id: null, code: null, description: 'SubjectId-I7N3G6G:visitId-2:fieldId-33 is deleted.' },
                     { successful: true, id: null, code: null, description: 'SubjectId-I7N3G6G:visitId-2:fieldId-34 is deleted.' }]);
-                const dataInDb = await db.collections!.data_collection.find({ 31: null }).sort({ uploadedAt: -1 }).toArray();
+                const dataInDb = await db.collections.data_collection.find({ 31: null }).sort({ uploadedAt: -1 }).toArray();
                 expect(dataInDb).toHaveLength(16); // 2 visits * 2 subjects * 2 fields * 2 (delete or not) = 16 records
             });
 
@@ -3908,7 +3908,7 @@ if (global.hasMinio) {
                     { successful: true, id: null, code: null, description: 'SubjectId-I7N3G6G:visitId-2:fieldId-32 is deleted.' },
                     { successful: true, id: null, code: null, description: 'SubjectId-I7N3G6G:visitId-2:fieldId-33 is deleted.' },
                     { successful: true, id: null, code: null, description: 'SubjectId-I7N3G6G:visitId-2:fieldId-34 is deleted.' }]);
-                const dataInDb = await db.collections!.data_collection.find({ m_subjectId: 'I7N3G6G' }).sort({ uploadedAt: -1 }).toArray();
+                const dataInDb = await db.collections.data_collection.find({ m_subjectId: 'I7N3G6G' }).sort({ uploadedAt: -1 }).toArray();
                 expect(dataInDb).toHaveLength(8); // two data records, two deleted records
             });
 
@@ -3993,13 +3993,13 @@ if (global.hasMinio) {
             // });
 
             // test('Get data records with meta data filters', async () => {
-            //     const study = await db.collections!.studies_collection.findOne({ id: createdStudy.id });
-            //     await db.collections!.field_dictionary_collection.updateMany({ fieldId: { $in: ['31', '32'] } }, {
+            //     const study = await db.collections.studies_collection.findOne({ id: createdStudy.id });
+            //     await db.collections.field_dictionary_collection.updateMany({ fieldId: { $in: ['31', '32'] } }, {
             //         $set: {
             //             [`metadata.role:${createdRole_study_accessData.id}`]: true
             //         }
             //     });
-            //     await db.collections!.data_collection.insertMany([{
+            //     await db.collections.data_collection.insertMany([{
             //         m_studyId: createdStudy.id,
             //         m_fieldId: '31',
             //         m_subjectId: 'I7N3G6G',
@@ -4056,7 +4056,7 @@ if (global.hasMinio) {
             //     expect(resMetadataOrg.body.data.getDataRecords.data).toEqual({
             //         I7N3G6G: { 1: { 31: '1', m_subjectId: 'I7N3G6G', m_visitId: '1' } }
             //     });
-            //     await db.collections!.studies_collection.findOneAndUpdate({ id: createdStudy.id }, { $set: { ontologyTrees: [] } });
+            //     await db.collections.studies_collection.findOneAndUpdate({ id: createdStudy.id }, { $set: { ontologyTrees: [] } });
             // });
 
             test('Create an ontology tree (authorised user)', async () => {
@@ -4083,7 +4083,7 @@ if (global.hasMinio) {
                         }
                     }
                 });
-                const study = await db.collections!.studies_collection.findOne({ id: createdStudy.id, deleted: null });
+                const study = await db.collections.studies_collection.findOne({ id: createdStudy.id, deleted: null });
                 expect(res.status).toBe(200);
                 expect(res.body.errors).toBeUndefined();
                 expect(res.body.data.createOntologyTree).toEqual({
@@ -4108,7 +4108,7 @@ if (global.hasMinio) {
                     metadata: null
                 });
                 // clear ontologyTrees
-                await db.collections!.studies_collection.findOneAndUpdate({ id: createdStudy.id, deleted: null }, {
+                await db.collections.studies_collection.findOneAndUpdate({ id: createdStudy.id, deleted: null }, {
                     $set: {
                         ontologyTrees: []
                     }
@@ -4173,7 +4173,7 @@ if (global.hasMinio) {
                     query: print(CREATE_NEW_DATA_VERSION),
                     variables: { studyId: createdStudy.id, dataVersion: '1', tag: 'testTag' }
                 });
-                const study: IStudy = await db.collections!.studies_collection.findOne({ id: createdStudy.id, deleted: null });
+                const study: IStudy = await db.collections.studies_collection.findOne({ id: createdStudy.id, deleted: null });
                 const res = await authorisedUser.post('/graphql').send({
                     query: print(DELETE_ONTOLOGY_TREE),
                     variables: {
@@ -4186,10 +4186,10 @@ if (global.hasMinio) {
                     id: study.ontologyTrees[0].name,
                     successful: true
                 });
-                const updatedStudy: IStudy = await db.collections!.studies_collection.findOne({ id: createdStudy.id, deleted: null });
+                const updatedStudy: IStudy = await db.collections.studies_collection.findOne({ id: createdStudy.id, deleted: null });
                 expect(updatedStudy.ontologyTrees.length).toBe(2); // both records
                 // clear study
-                await db.collections!.studies_collection.findOneAndUpdate({ id: createdStudy.id, deleted: null }, {
+                await db.collections.studies_collection.findOneAndUpdate({ id: createdStudy.id, deleted: null }, {
                     $set: {
                         dataVersions: [],
                         currentDataVersion: -1,
@@ -4222,7 +4222,7 @@ if (global.hasMinio) {
                         }
                     }
                 });
-                const study: IStudy = await db.collections!.studies_collection.findOne({ id: createdStudy.id, deleted: null });
+                const study: IStudy = await db.collections.studies_collection.findOne({ id: createdStudy.id, deleted: null });
                 const res = await user.post('/graphql').send({
                     query: print(DELETE_ONTOLOGY_TREE),
                     variables: {
@@ -4234,7 +4234,7 @@ if (global.hasMinio) {
                 expect(res.body.data.deleteOntologyTree).toBe(null);
                 expect(res.body.errors).toHaveLength(1);
                 expect(res.body.errors[0].message).toBe(errorCodes.NO_PERMISSION_ERROR);
-                await db.collections!.studies_collection.findOneAndUpdate({ studyId: createdStudy.id, deleted: null }, {
+                await db.collections.studies_collection.findOneAndUpdate({ studyId: createdStudy.id, deleted: null }, {
                     $set: {
                         ontologyTrees: []
                     }
@@ -4292,7 +4292,7 @@ if (global.hasMinio) {
                         }
                     }
                 });
-                const study: IStudy = await db.collections!.studies_collection.findOne({ id: createdStudy.id, deleted: null });
+                const study: IStudy = await db.collections.studies_collection.findOne({ id: createdStudy.id, deleted: null });
                 const resWithoutVersion = await authorisedUser.post('/graphql').send({
                     query: print(GET_ONTOLOGY_TREE),
                     variables: {
@@ -4355,7 +4355,7 @@ if (global.hasMinio) {
                     metadata: null
                 });
                 // clear study
-                await db.collections!.studies_collection.findOneAndUpdate({ id: createdStudy.id, deleted: null }, {
+                await db.collections.studies_collection.findOneAndUpdate({ id: createdStudy.id, deleted: null }, {
                     $set: {
                         dataVersions: [],
                         currentDataVersion: -1,
@@ -4405,7 +4405,7 @@ if (global.hasMinio) {
                 expect(res.body.errors).toHaveLength(1);
                 expect(res.body.errors[0].message).toBe(errorCodes.NO_PERMISSION_ERROR);
                 // clear study
-                await db.collections!.studies_collection.findOneAndUpdate({ id: createdStudy.id, deleted: null }, {
+                await db.collections.studies_collection.findOneAndUpdate({ id: createdStudy.id, deleted: null }, {
                     $set: {
                         dataVersions: [],
                         currentDataVersion: -1,
@@ -4455,7 +4455,7 @@ if (global.hasMinio) {
                 expect(res.body.errors).toHaveLength(1);
                 expect(res.body.errors[0].message).toBe(errorCodes.NO_PERMISSION_ERROR);
                 // clear study
-                await db.collections!.studies_collection.findOneAndUpdate({ id: createdStudy.id, deleted: null }, {
+                await db.collections.studies_collection.findOneAndUpdate({ id: createdStudy.id, deleted: null }, {
                     $set: {
                         dataVersions: [],
                         currentDataVersion: -1,
@@ -4471,7 +4471,7 @@ if (global.hasMinio) {
                 });
                 // edit a field so that the datatype mismatched with the exisiting value
                 // this happens when a field is deleted first and then modified and added, while some data has been uploaded before deleting, causing conflicts
-                await db.collections!.field_dictionary_collection.findOneAndUpdate({
+                await db.collections.field_dictionary_collection.findOneAndUpdate({
                     studyId: createdStudy.id,
                     fieldId: '32'
                 }, {

--- a/packages/itmat-interface/test/serverTests/users.test.ts
+++ b/packages/itmat-interface/test/serverTests/users.test.ts
@@ -92,7 +92,7 @@ beforeAll(async () => { // eslint-disable-line no-undef
     if (config.nodemailer.auth === undefined)
         config.nodemailer.auth = {
             auth: {}
-        } as any;
+        };
     if (TEST_SMTP_CRED)
         config.nodemailer.auth.pass = TEST_SMTP_CRED;
     if (TEST_SMTP_USERNAME)
@@ -196,7 +196,7 @@ describe('USERS API', () => {
 
         test('Request reset password with existing user providing email', async () => {
             /* setup: replacing the seed user's email with slurp test email */
-            const updateResult = await db.collections!.users_collection.findOneAndUpdate({
+            const updateResult = await db.collections.users_collection.findOneAndUpdate({
                 username: SEED_STANDARD_USER_USERNAME
             }, { $set: { email: TEMP_USER_TEST_EMAIL } });
             expect(updateResult).not.toBeNull();
@@ -215,7 +215,7 @@ describe('USERS API', () => {
             expect(res.status).toBe(200);
             expect(res.body.errors).toBeUndefined();
             expect(res.body.data.requestUsernameOrResetPassword).toEqual({ successful: true });
-            const modifiedUser = await db.collections!.users_collection.findOne({ username: SEED_STANDARD_USER_USERNAME });
+            const modifiedUser = await db.collections.users_collection.findOne({ username: SEED_STANDARD_USER_USERNAME });
             expect(modifiedUser).toBeDefined();
             expect(modifiedUser.resetPasswordRequests).toHaveLength(1);
             expect(typeof modifiedUser.resetPasswordRequests[0].id).toBe('string');
@@ -224,14 +224,14 @@ describe('USERS API', () => {
             expect(new Date().valueOf() - modifiedUser.resetPasswordRequests[0].timeOfRequest).toBeLessThan(15000); // less then 5 seconds
 
             /* cleanup: changing the user's email back */
-            const cleanupResult = await db.collections!.users_collection.findOneAndUpdate({ username: SEED_STANDARD_USER_USERNAME }, { $set: { email: SEED_STANDARD_USER_EMAIL, resetPasswordRequests: [] } }, { returnDocument: 'after' });
+            const cleanupResult = await db.collections.users_collection.findOneAndUpdate({ username: SEED_STANDARD_USER_USERNAME }, { $set: { email: SEED_STANDARD_USER_EMAIL, resetPasswordRequests: [] } }, { returnDocument: 'after' });
             expect(cleanupResult).not.toBeNull();
             expect(cleanupResult.email).toBe(SEED_STANDARD_USER_EMAIL);
         }, 30000);
 
         test('Request reset password with existing user providing username', async () => {
             /* setup: replacing the seed user's email with test email */
-            const updateResult = await db.collections!.users_collection.findOneAndUpdate({
+            const updateResult = await db.collections.users_collection.findOneAndUpdate({
                 username: SEED_STANDARD_USER_USERNAME
             }, { $set: { email: TEMP_USER_TEST_EMAIL } });
             expect(updateResult).not.toBeNull();
@@ -250,7 +250,7 @@ describe('USERS API', () => {
             expect(res.status).toBe(200);
             expect(res.body.errors).toBeUndefined();
             expect(res.body.data.requestUsernameOrResetPassword).toEqual({ successful: true });
-            const modifiedUser = await db.collections!.users_collection.findOne({ username: SEED_STANDARD_USER_USERNAME });
+            const modifiedUser = await db.collections.users_collection.findOne({ username: SEED_STANDARD_USER_USERNAME });
             expect(modifiedUser).toBeDefined();
             expect(modifiedUser.resetPasswordRequests).toHaveLength(1);
             expect(typeof modifiedUser.resetPasswordRequests[0].id).toBe('string');
@@ -259,7 +259,7 @@ describe('USERS API', () => {
             expect(new Date().valueOf() - modifiedUser.resetPasswordRequests[0].timeOfRequest).toBeLessThan(15000); // less then 5 seconds
 
             /* cleanup: changing the user's email back */
-            const cleanupResult = await db.collections!.users_collection.findOneAndUpdate({ username: SEED_STANDARD_USER_USERNAME }, { $set: { email: SEED_STANDARD_USER_EMAIL, resetPasswordRequests: [] } }, { returnDocument: 'after' });
+            const cleanupResult = await db.collections.users_collection.findOneAndUpdate({ username: SEED_STANDARD_USER_USERNAME }, { $set: { email: SEED_STANDARD_USER_EMAIL, resetPasswordRequests: [] } }, { returnDocument: 'after' });
             expect(cleanupResult).not.toBeNull();
             expect(cleanupResult.email).toBe(SEED_STANDARD_USER_EMAIL);
         }, 30000);
@@ -288,7 +288,7 @@ describe('USERS API', () => {
                 timeOfRequest: new Date().valueOf(),
                 used: false
             };
-            const updateResult = await db.collections!.users_collection.findOneAndUpdate(
+            const updateResult = await db.collections.users_collection.findOneAndUpdate(
                 { username: SEED_STANDARD_USER_USERNAME },
                 { $set: { resetPasswordRequests: [resetPWrequest] } }
             );
@@ -311,7 +311,7 @@ describe('USERS API', () => {
             expect(res.body.data.resetPassword).toBe(null);
 
             /* cleanup */
-            const updateResult2 = await db.collections!.users_collection.findOneAndUpdate(
+            const updateResult2 = await db.collections.users_collection.findOneAndUpdate(
                 { username: SEED_STANDARD_USER_USERNAME },
                 { $set: { resetPasswordRequests: [] } }
             );
@@ -327,7 +327,7 @@ describe('USERS API', () => {
                 timeOfRequest: new Date().valueOf(),
                 used: false
             };
-            const updateResult = await db.collections!.users_collection.findOneAndUpdate(
+            const updateResult = await db.collections.users_collection.findOneAndUpdate(
                 { username: SEED_STANDARD_USER_USERNAME },
                 { $set: { resetPasswordRequests: [resetPWrequest] } }
             );
@@ -350,7 +350,7 @@ describe('USERS API', () => {
             expect(res.body.data.resetPassword).toBe(null);
 
             /* cleanup */
-            const updateResult2 = await db.collections!.users_collection.findOneAndUpdate(
+            const updateResult2 = await db.collections.users_collection.findOneAndUpdate(
                 { username: SEED_STANDARD_USER_USERNAME },
                 { $set: { resetPasswordRequests: [] } }
             );
@@ -364,7 +364,7 @@ describe('USERS API', () => {
                 timeOfRequest: new Date().valueOf() - 60 * 60 * 1000 /* (default expiry: 1hr) */ - 1,
                 used: false
             };
-            const updateResult = await db.collections!.users_collection.findOneAndUpdate(
+            const updateResult = await db.collections.users_collection.findOneAndUpdate(
                 { username: SEED_STANDARD_USER_USERNAME },
                 { $set: { resetPasswordRequests: [resetPWrequest] } }
             );
@@ -387,7 +387,7 @@ describe('USERS API', () => {
             expect(res.body.data.resetPassword).toBe(null);
 
             /* cleanup */
-            const updateResult2 = await db.collections!.users_collection.findOneAndUpdate(
+            const updateResult2 = await db.collections.users_collection.findOneAndUpdate(
                 { username: SEED_STANDARD_USER_USERNAME },
                 { $set: { resetPasswordRequests: [] } }
             );
@@ -409,7 +409,7 @@ describe('USERS API', () => {
                     used: false
                 }
             ];
-            const updateResult = await db.collections!.users_collection.findOneAndUpdate(
+            const updateResult = await db.collections.users_collection.findOneAndUpdate(
                 { username: SEED_STANDARD_USER_USERNAME },
                 { $set: { resetPasswordRequests: resetPWrequests } }
             );
@@ -432,7 +432,7 @@ describe('USERS API', () => {
             expect(res.body.data.resetPassword).toBe(null);
 
             /* cleanup */
-            const updateResult2 = await db.collections!.users_collection.findOneAndUpdate(
+            const updateResult2 = await db.collections.users_collection.findOneAndUpdate(
                 { username: SEED_STANDARD_USER_USERNAME },
                 { $set: { resetPasswordRequests: [] } }
             );
@@ -446,7 +446,7 @@ describe('USERS API', () => {
                 timeOfRequest: new Date().valueOf(),
                 used: false
             };
-            const updateResult = await db.collections!.users_collection.findOneAndUpdate(
+            const updateResult = await db.collections.users_collection.findOneAndUpdate(
                 { username: SEED_STANDARD_USER_USERNAME },
                 { $set: { resetPasswordRequests: [resetPWrequest] } }
             );
@@ -467,7 +467,7 @@ describe('USERS API', () => {
             expect(res.status).toBe(200);
             expect(res.body.errors).toBeUndefined();
             expect(res.body.data.resetPassword).toEqual({ successful: true });
-            const checkedUser = await db.collections!.users_collection.findOne({ username: SEED_STANDARD_USER_USERNAME });
+            const checkedUser = await db.collections.users_collection.findOne({ username: SEED_STANDARD_USER_USERNAME });
             await connectAgent(newloggedoutuser, SEED_STANDARD_USER_USERNAME, 'securepasswordrighthere', checkedUser.otpSecret);
             const whoami = await newloggedoutuser.post('/graphql').send({ query: print(WHO_AM_I) });
             expect(whoami.status).toBe(200);
@@ -495,7 +495,7 @@ describe('USERS API', () => {
             });
 
             /* cleanup */
-            const updateResult2 = await db.collections!.users_collection.findOneAndUpdate(
+            const updateResult2 = await db.collections.users_collection.findOneAndUpdate(
                 { username: SEED_STANDARD_USER_USERNAME },
                 { $set: { resetPasswordRequests: [], password: '$2b$04$j0aSK.Dyq7Q9N.r6d0uIaOGrOe7sI4rGUn0JNcaXcPCv.49Otjwpi' } }
             );
@@ -516,7 +516,7 @@ describe('USERS API', () => {
                     used: false
                 }
             ];
-            const updateResult = await db.collections!.users_collection.findOneAndUpdate(
+            const updateResult = await db.collections.users_collection.findOneAndUpdate(
                 { username: SEED_STANDARD_USER_USERNAME },
                 { $set: { resetPasswordRequests: resetPWrequest } }
             );
@@ -535,7 +535,7 @@ describe('USERS API', () => {
             expect(res.status).toBe(200);
             expect(res.body.errors).toBeUndefined();
             expect(res.body.data.resetPassword).toEqual({ successful: true });
-            const checkedUser = await db.collections!.users_collection.findOne({ username: SEED_STANDARD_USER_USERNAME });
+            const checkedUser = await db.collections.users_collection.findOne({ username: SEED_STANDARD_USER_USERNAME });
             await connectAgent(newloggedoutuser, SEED_STANDARD_USER_USERNAME, 'securepasswordrighthere', checkedUser.otpSecret);
             const whoami = await newloggedoutuser.post('/graphql').send({ query: print(WHO_AM_I) });
             expect(whoami.status).toBe(200);
@@ -579,7 +579,7 @@ describe('USERS API', () => {
             expect(resAgain.body.data.resetPassword).toEqual(null);
 
             /* cleanup */
-            const updateResult2 = await db.collections!.users_collection.findOneAndUpdate(
+            const updateResult2 = await db.collections.users_collection.findOneAndUpdate(
                 { username: SEED_STANDARD_USER_USERNAME },
                 { $set: { resetPasswordRequests: [], password: '$2b$04$j0aSK.Dyq7Q9N.r6d0uIaOGrOe7sI4rGUn0JNcaXcPCv.49Otjwpi' } }
             );

--- a/packages/itmat-job-executor/src/curation/CSVCurator.ts
+++ b/packages/itmat-job-executor/src/curation/CSVCurator.ts
@@ -46,7 +46,7 @@ export class CSVCurator {
             const csvparseStream = csvparse.parse(this.parseOptions);
             const parseStream = this.incomingWebStream.pipe(csvparseStream); // piping the incoming stream to a parser stream
 
-            csvparseStream.on('skip', (error: any) => {
+            csvparseStream.on('skip', (error) => {
                 lineNum++;
                 this._errored = true;
                 this._errors.push(error.toString());
@@ -187,11 +187,11 @@ export function processDataRow({ subjectIdIndex, visitIdIndex, lineNum, row, par
     /* pure function */
     const error: string[] = [];
     let colIndex = 0;
-    const dataEntry: any = {
+    const dataEntry = {
         m_studyId: job.studyId,
         m_versionId: null,
         deleted: null
-    };
+    } as any;
     if (row.length !== (parsedHeader.filter(el => el !== undefined).length + 1)) {
         error.push(`Line ${lineNum}: Uneven field Number; expected ${parsedHeader.length + 1} fields but got ${row.length}`);
         return ({ error, dataEntry });
@@ -231,7 +231,7 @@ export function processDataRow({ subjectIdIndex, visitIdIndex, lineNum, row, par
             continue;
         }
         /* adding value to dataEntry */
-        let value: any;
+        let value;
         try {
             if (each.toString() === '99999') {
                 value = '99999';

--- a/packages/itmat-job-executor/src/curation/FieldCurator.ts
+++ b/packages/itmat-job-executor/src/curation/FieldCurator.ts
@@ -41,7 +41,7 @@ export class FieldCurator {
             const csvparseStream = csvparse.parse(this.parseOptions);
             const parseStream = this.incomingWebStream.pipe(csvparseStream); // piping the incoming stream to a parser stream
 
-            csvparseStream.on('skip', (error: any) => {
+            csvparseStream.on('skip', (error) => {
                 lineNum++;
                 this._errored = true;
                 this._errors.push(error.toString());

--- a/packages/itmat-job-executor/src/curation/JSONCurator.ts
+++ b/packages/itmat-job-executor/src/curation/JSONCurator.ts
@@ -174,10 +174,10 @@ export function processEachSubject({ subjectIdIndex, visitIdIndex, objectNum, su
     /* pure function */
     const error: string[] = [];
     let colIndex = 0;
-    const dataEntry: any = {
+    const dataEntry = {
         m_studyId: job.studyId,
         deleted: null
-    };
+    } as any;
     if (subject.length !== (parsedHeader.filter(el => el !== undefined).length + 1)) {
         error.push(`Object ${objectNum}: Uneven field Number; expected ${parsedHeader.length + 1} fields but got ${subject.length}`);
         return ({ error, dataEntry });
@@ -217,7 +217,7 @@ export function processEachSubject({ subjectIdIndex, visitIdIndex, objectNum, su
             continue;
         }
         /* adding value to dataEntry */
-        let value: any;
+        let value;
         try {
             if (each.toString() === '99999') {
                 value = '99999';

--- a/packages/itmat-job-executor/src/index.ts
+++ b/packages/itmat-job-executor/src/index.ts
@@ -60,7 +60,7 @@ function serverSpinning() {
 
 serverSpinning();
 
-declare const module: any;
+declare const module;
 if (module.hot) {
     module.hot.accept('./index', serverSpinning);
     module.hot.accept('./jobExecutorRunner', serverSpinning);

--- a/packages/itmat-job-executor/src/jobExecutorRunner.ts
+++ b/packages/itmat-job-executor/src/jobExecutorRunner.ts
@@ -45,7 +45,7 @@ class ITMATJobExecutorRunner extends Runner {
 
                     const poller = new JobPoller({
                         identity: uuid(),
-                        jobCollection: db.collections!.jobs_collection,
+                        jobCollection: db.collections.jobs_collection,
                         pollingInterval: this.config.pollingInterval,
                         action: jobDispatcher.dispatch
                     });
@@ -54,7 +54,7 @@ class ITMATJobExecutorRunner extends Runner {
                     // Return the Express application
                     return resolve(_this.router);
 
-                }).catch((err: any) => reject(err));
+                }).catch((err) => reject(err));
         });
     }
 

--- a/packages/itmat-job-executor/src/jobHandlers/UKB_CSV_UPLOAD_Handler.ts
+++ b/packages/itmat-job-executor/src/jobHandlers/UKB_CSV_UPLOAD_Handler.ts
@@ -27,11 +27,11 @@ export class UKB_CSV_UPLOAD_Handler extends JobHandler {
             error: string | string[];
         }> = [];
         // get fieldid info from database
-        const fieldsList = await db.collections!.field_dictionary_collection.find({ studyId: job.studyId }).toArray();
+        const fieldsList = await db.collections.field_dictionary_collection.find({ studyId: job.studyId }).toArray();
 
         for (const fileId of job.receivedFiles) {
             try {
-                const file = await db.collections!.files_collection.findOne({ id: fileId, deleted: null })!;
+                const file = await db.collections.files_collection.findOne({ id: fileId, deleted: null })!;
                 if (!file) {
                     errorsList.push({ fileId: fileId, error: 'file does not exist' });
                     continue;
@@ -42,7 +42,7 @@ export class UKB_CSV_UPLOAD_Handler extends JobHandler {
                 const filteredFieldsList = fieldsList.filter(el => el.tableName === tableName);
                 const fileStream: Readable = await objStore.downloadFile(job.studyId, file.uri);
                 const csvcurator = new CSVCurator(
-                    db.collections!.data_collection,
+                    db.collections.data_collection,
                     fileStream,
                     undefined,
                     job,
@@ -51,9 +51,9 @@ export class UKB_CSV_UPLOAD_Handler extends JobHandler {
                 const errors = await csvcurator.processIncomingStreamAndUploadToMongo();
                 if (errors.length !== 0) {
                     errorsList.push({ fileId: file.id, fileName: file.fileName, error: errors });
-                    await db.collections!.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'error', error: errorsList as any } });
+                    await db.collections.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'error', error: errorsList } });
                 } else {
-                    await db.collections!.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'finished' } });
+                    await db.collections.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'finished' } });
                 }
             } catch (e) {
                 throw new Error();

--- a/packages/itmat-job-executor/src/jobHandlers/UKB_FIELD_INFO_UPLOAD_Handler.ts
+++ b/packages/itmat-job-executor/src/jobHandlers/UKB_FIELD_INFO_UPLOAD_Handler.ts
@@ -17,12 +17,12 @@ export class UKB_FIELD_INFO_UPLOAD_Handler extends JobHandler {
     }
 
     public async execute(job: IJobEntryForFieldCuration) {
-        const file = await db.collections!.files_collection.findOne({ id: job.receivedFiles[0], deleted: null })!;
+        const file = await db.collections.files_collection.findOne({ id: job.receivedFiles[0], deleted: null })!;
         if (!file) {
             throw new Error('File does not exists.');
         }
 
-        const codesFile = await db.collections!.files_collection.findOne({ fileName: 'prolific_Codes.csv' });
+        const codesFile = await db.collections.files_collection.findOne({ fileName: 'prolific_Codes.csv' });
         if (!codesFile) {
             throw new Error('Codes File does not exists.');
         }
@@ -32,7 +32,7 @@ export class UKB_FIELD_INFO_UPLOAD_Handler extends JobHandler {
 
         const fileStream: Readable = await objStore.downloadFile(job.studyId, file.uri);
         const fieldcurator = new FieldCurator(
-            db.collections!.field_dictionary_collection,
+            db.collections.field_dictionary_collection,
             fileStream,
             undefined,
             job,
@@ -41,19 +41,19 @@ export class UKB_FIELD_INFO_UPLOAD_Handler extends JobHandler {
         const errors = await fieldcurator.processIncomingStreamAndUploadToMongo();
 
         if (errors.length !== 0) {
-            await db.collections!.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'error', error: errors as any } });
+            await db.collections.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'error', error: errors } });
             return;
         } else {
-            await db.collections!.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'finished' } });
+            await db.collections.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'finished' } });
             // await this.updateFieldTreesInMongo(job, fieldTreeId);
         }
 
     }
 
     // public async updateFieldTreesInMongo(job: IJobEntryForFieldCuration, fieldTreeId: string) {
-    //     const queryObject = { 'id': job.studyId, 'deleted': null, 'dataVersions.id': job.data!.dataVersionId };
+    //     const queryObject = { 'id': job.studyId, 'deleted': null, 'dataVersions.id': job.data.dataVersionId };
     //     const updateObject = { $push: { 'dataVersions.$.fieldTrees': fieldTreeId } };
-    //     return await db.collections!.studies_collection.findOneAndUpdate(queryObject, updateObject);
+    //     return await db.collections.studies_collection.findOneAndUpdate(queryObject, updateObject);
     // }
 }
 
@@ -66,7 +66,7 @@ function processCodesFileStreamAndReturnList(incomingStream: Readable): Promise<
     // });
 
     let isHeader = true;
-    const codes: any = {};
+    const codes = {};
 
     const CORRECT_NUMBER_OF_COLUMN = 4;
     const uploadWriteStream: NodeJS.WritableStream = new Writable({

--- a/packages/itmat-job-executor/src/jobHandlers/UKB_JSON_UPLOAD_Handler.ts
+++ b/packages/itmat-job-executor/src/jobHandlers/UKB_JSON_UPLOAD_Handler.ts
@@ -23,11 +23,11 @@ export class UKB_JSON_UPLOAD_Handler extends JobHandler {
             error: string | string[];
         }> = [];
         // get fieldid info from database
-        const fieldsList = await db.collections!.field_dictionary_collection.find({ studyId: job.studyId }).toArray();
+        const fieldsList = await db.collections.field_dictionary_collection.find({ studyId: job.studyId }).toArray();
 
         for (const fileId of job.receivedFiles) {
             try {
-                const file = await db.collections!.files_collection.findOne({ id: fileId, deleted: null })!;
+                const file = await db.collections.files_collection.findOne({ id: fileId, deleted: null })!;
                 if (!file) {
                     errorsList.push({ fileId: fileId, error: 'file does not exist' });
                     continue;
@@ -38,7 +38,7 @@ export class UKB_JSON_UPLOAD_Handler extends JobHandler {
                 const filteredFieldsList = fieldsList.filter(el => el.tableName === tableName);
                 const fileStream: Readable = await objStore.downloadFile(job.studyId, file.uri);
                 const jsoncurator = new JSONCurator(
-                    db.collections!.data_collection,
+                    db.collections.data_collection,
                     fileStream,
                     job,
                     filteredFieldsList
@@ -46,9 +46,9 @@ export class UKB_JSON_UPLOAD_Handler extends JobHandler {
                 const errors = await jsoncurator.processIncomingStreamAndUploadToMongo();
                 if (errors.length !== 0) {
                     errorsList.push({ fileId: file.id, fileName: file.fileName, error: errors });
-                    await db.collections!.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'error', error: errorsList as any } });
+                    await db.collections.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'error', error: errorsList } });
                 } else {
-                    await db.collections!.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'finished' } });
+                    await db.collections.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'finished' } });
                 }
             } catch (e) {
                 throw new Error();

--- a/packages/itmat-job-executor/src/query/pipeLineGenerator.ts
+++ b/packages/itmat-job-executor/src/query/pipeLineGenerator.ts
@@ -45,7 +45,7 @@ class PipelineGenerator {
         }
     }
     */
-    public buildPipeline(query: any, studyId: string, availableDataVersions: any) {
+    public buildPipeline(query, studyId: string, availableDataVersions) {
         // check query, then decide whether to parse the query
         if (query['data_requested'] === undefined || query['cohort'] === undefined || query['new_fields'] === undefined) {
             return null;
@@ -56,16 +56,16 @@ class PipelineGenerator {
 
         const fields = { _id: 0, m_subjectId: 1, m_visitId: 1 };
         // We send back the requested fields
-        query.data_requested.forEach((field: any) => {
-            (fields as any)[field] = 1;
+        query.data_requested.forEach((field) => {
+            fields[field] = 1;
         });
         const addFields = {};
         // We send back the newly created derived fields by default
         if (query.new_fields.length > 0) {
-            query.new_fields.forEach((field: any) => {
+            query.new_fields.forEach((field) => {
                 if (field.op === 'derived') {
-                    (fields as any)[field.name] = 1;
-                    (addFields as any)[field.name] = this._createNewField(field.value);
+                    fields[field.name] = 1;
+                    addFields[field.name] = this._createNewField(field.value);
                 } else {
                     return 'Error';
                 }
@@ -73,8 +73,8 @@ class PipelineGenerator {
         }
         let match = {};
         if (query.cohort.length > 1) {
-            const subqueries: any = [];
-            query.cohort.forEach((subcohort: any) => {
+            const subqueries: any[] = [];
+            query.cohort.forEach((subcohort) => {
                 // addFields.
                 subqueries.push(this._translateCohort(subcohort));
             });
@@ -82,7 +82,7 @@ class PipelineGenerator {
         } else {
             match = this._translateCohort(query.cohort[0]);
         }
-        let dataVersionsFilter: any;
+        let dataVersionsFilter;
         if (availableDataVersions == null) {
             dataVersionsFilter = null;
         } else {
@@ -118,7 +118,7 @@ class PipelineGenerator {
      * @return json formated in the mongo format in the pipeline stage addfield
      * @private
      */
-    private _createNewField(expression: any) {
+    private _createNewField(expression) {
         let newField = {};
         switch (expression.op) {
             case '*':
@@ -167,7 +167,7 @@ class PipelineGenerator {
      * @returns {boolean}
      * @private
      */
-    private _isEmptyObject(obj: any) {
+    private _isEmptyObject(obj) {
         return !Object.keys(obj).length;
     }
 
@@ -177,59 +177,59 @@ class PipelineGenerator {
      * @param cohort
      * @private
      */
-    private _translateCohort(cohort: any) {
+    private _translateCohort(cohort) {
         const match = {};
 
-        cohort.forEach(function (select: any) {
+        cohort.forEach(function (select) {
 
             switch (select.op) {
                 case '=':
                     // select.value must be an array
-                    (match as any)[select.field] = { $in: [select.value] };
+                    match[select.field] = { $in: [select.value] };
                     break;
                 case '!=':
                     // select.value must be an array
-                    (match as any)[select.field] = { $ne: [select.value] };
+                    match[select.field] = { $ne: [select.value] };
                     break;
                 case '<':
                     // select.value must be a float
-                    (match as any)[select.field] = { $lt: parseFloat(select.value) };
+                    match[select.field] = { $lt: parseFloat(select.value) };
                     break;
                 case '>':
                     // select.value must be a float
-                    (match as any)[select.field] = { $gt: parseFloat(select.value) };
+                    match[select.field] = { $gt: parseFloat(select.value) };
                     break;
                 case 'derived': {
                     // equation must only have + - * /
                     const derivedOperation = select.value.split(' ');
                     if (derivedOperation[0] === '=') {
-                        (match as any)[select.field] = { $eq: parseFloat(select.value) };
+                        match[select.field] = { $eq: parseFloat(select.value) };
                     }
                     if (derivedOperation[0] === '>') {
-                        (match as any)[select.field] = { $gt: parseFloat(select.value) };
+                        match[select.field] = { $gt: parseFloat(select.value) };
                     }
                     if (derivedOperation[0] === '<') {
-                        (match as any)[select.field] = { $lt: parseFloat(select.value) };
+                        match[select.field] = { $lt: parseFloat(select.value) };
                     }
                     break;
                 }
                 case 'exists':
                     // We check if the field exists. This is to be used for checking if a patient
                     // has an image
-                    (match as any)[select.field] = { $exists: true };
+                    match[select.field] = { $exists: true };
                     break;
                 case 'count': {
                     // counts can only be positive. NB: > and < are inclusive e.g. < is <=
                     const countOperation = select.value.split(' ');
                     const countfield = select.field + '.count';
                     if (countOperation[0] === '=') {
-                        (match as any)[countfield] = { $eq: parseInt(countOperation[1], 10) };
+                        match[countfield] = { $eq: parseInt(countOperation[1], 10) };
                     }
                     if (countOperation[0] === '>') {
-                        (match as any)[countfield] = { $gt: parseInt(countOperation[1], 10) };
+                        match[countfield] = { $gt: parseInt(countOperation[1], 10) };
                     }
                     if (countOperation[0] === '<') {
-                        (match as any)[countfield] = { $lt: parseInt(countOperation[1], 10) };
+                        match[countfield] = { $lt: parseInt(countOperation[1], 10) };
                     }
                     break;
                 }

--- a/packages/itmat-job-executor/src/query/queryHandler.ts
+++ b/packages/itmat-job-executor/src/query/queryHandler.ts
@@ -17,14 +17,14 @@ export class QueryHandler extends JobHandler {
 
     public async execute(job: IJobEntry<{ queryId: string[], projectId: string, studyId: string }>) {
         // get available data versions
-        const thisProject = await db.collections!.projects_collection.findOne({ id: job.data?.projectId });
-        const availableDataVersions = [thisProject!.dataVersion];
+        const thisProject = await db.collections.projects_collection.findOne({ id: job.data?.projectId });
+        const availableDataVersions = [thisProject.dataVersion];
         const queryId = job.data?.queryId[0];
-        const queryString = await db.collections!.queries_collection.findOne({ id: queryId })!;
-        const pipeline = pipelineGenerator.buildPipeline(queryString!.queryString, job.studyId, availableDataVersions);
+        const queryString = await db.collections.queries_collection.findOne({ id: queryId })!;
+        const pipeline = pipelineGenerator.buildPipeline(queryString.queryString, job.studyId, availableDataVersions);
         if (!pipeline) {
             /* update query status */
-            await db.collections!.queries_collection.findOneAndUpdate({ queryId }, {
+            await db.collections.queries_collection.findOneAndUpdate({ queryId }, {
                 $set: {
                     error: 'Pipeline was not generated properly',
                     status: 'FINISHED WITH ERROR'
@@ -33,12 +33,12 @@ export class QueryHandler extends JobHandler {
             return;
         }
         try {
-            const result = await db.collections!.data_collection.aggregate(pipeline).toArray();
+            const result = await db.collections.data_collection.aggregate(pipeline).toArray();
             /* if the query is on a project, then we need to map the results m_eid */
             if (job.projectId) {
-                const project = await db.collections!.projects_collection.findOne({ id: job.data?.projectId })!;
+                const project = await db.collections.projects_collection.findOne({ id: job.data?.projectId })!;
                 if (project === null || project === undefined) {
-                    await db.collections!.queries_collection.findOneAndUpdate({ queryId }, {
+                    await db.collections.queries_collection.findOneAndUpdate({ queryId }, {
                         $set: {
                             error: 'Project does not exist or has been deleted.',
                             status: 'FINISHED WITH ERROR'
@@ -52,20 +52,20 @@ export class QueryHandler extends JobHandler {
                     el.m_eid = mapping[el.m_eid];
                 });
             }
-            await db.collections!.queries_collection.findOneAndUpdate({ id: queryId }, {
+            await db.collections.queries_collection.findOneAndUpdate({ id: queryId }, {
                 $set: {
                     queryResult: JSON.stringify(result),
                     status: 'FINISHED'
                 }
             });
-            await db.collections!.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'finished' } });
+            await db.collections.jobs_collection.updateOne({ id: job.id }, { $set: { status: 'finished' } });
             return;
-        } catch (e: any) {
+        } catch (e) {
             /* log */
             Logger.error(e.toString());
 
             /* update query status */
-            await db.collections!.queries_collection.findOneAndUpdate({ queryId }, {
+            await db.collections.queries_collection.findOneAndUpdate({ queryId }, {
                 $set: {
                     error: e.toString(),
                     status: 'FINISHED WITH ERROR'

--- a/packages/itmat-types/src/index.ts
+++ b/packages/itmat-types/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './devices';
+export * from './permissions';

--- a/packages/itmat-types/src/types/data.ts
+++ b/packages/itmat-types/src/types/data.ts
@@ -5,8 +5,8 @@ export interface IDataEntry {
     m_visitId: string; // visit Id
     m_versionId: string | null; // data version Id
     m_fieldId: string;
-    metadata?: any;
-    value: any;
+    metadata?: JSON;
+    value;
     uploadedBy?: string;
     uploadedAt: number;
 }

--- a/packages/itmat-types/src/types/email.ts
+++ b/packages/itmat-types/src/types/email.ts
@@ -1,0 +1,9 @@
+import { Attachment } from 'nodemailer/lib/mailer';
+
+export interface IMail {
+    from: string,
+    to: string,
+    subject: string,
+    html: string,
+    attachments?: Attachment[];
+}

--- a/packages/itmat-types/src/types/field.ts
+++ b/packages/itmat-types/src/types/field.ts
@@ -5,10 +5,10 @@ export interface IFieldEntry {
     fieldName: string;
     tableName?: string;
     dataType: enumValueType;
-    possibleValues?: IValueDescription[];
+    possibleValues?: IValueDescription[] | null;
     unit?: string;
     comments?: string;
-    metadata?: any;
+    metadata?;
     dateAdded: string;
     dateDeleted: string | null;
     dataVersion: string | null;

--- a/packages/itmat-types/src/types/index.ts
+++ b/packages/itmat-types/src/types/index.ts
@@ -9,6 +9,7 @@ import * as Organisation from './organisation';
 import * as Pubkey from './pubkey';
 import * as Data from './data';
 import * as Standardization from './standardization';
+import * as Email from './email';
 
 export * from './field';
 export * from './file';
@@ -21,4 +22,5 @@ export * from './organisation';
 export * from './pubkey';
 export * from './data';
 export * from './standardization';
-export const Types = { File, Job, Log, User, Organisation, Pubkey, Study, Query, Field, Data, Standardization };
+export * from './email';
+export const Types = { File, Job, Log, User, Organisation, Pubkey, Study, Query, Field, Data, Standardization, Email };

--- a/packages/itmat-types/src/types/log.ts
+++ b/packages/itmat-types/src/types/log.ts
@@ -7,7 +7,7 @@ export interface ILogEntry {
     userAgent: USER_AGENT,
     logType: LOG_TYPE,
     actionType: LOG_ACTION,
-    actionData: any,
+    actionData: string,
     time: number,
     status: LOG_STATUS,
     errors: string | null

--- a/packages/itmat-types/src/types/query.ts
+++ b/packages/itmat-types/src/types/query.ts
@@ -1,6 +1,11 @@
 export type IQueryEntry = {
     id: string;
-    queryString: any;
+    queryString: {
+        data_requested: string[];
+        cohort: ICohortSelection[][];
+        new_fields: INewFieldSelection[];
+        format?: string
+    };
     studyId: string;
     projectId?: string;
     requester: string;

--- a/packages/itmat-types/src/types/standardization.ts
+++ b/packages/itmat-types/src/types/standardization.ts
@@ -28,5 +28,5 @@ export interface IStandardizationRule {
     source: StandardizationRuleSource,
     parameter: string[],
     // further processings for a value: delete, convert, etc.
-    filters?: any
+    filters?
 }

--- a/packages/itmat-types/src/types/user.ts
+++ b/packages/itmat-types/src/types/user.ts
@@ -14,12 +14,12 @@ export interface IUserWithoutToken {
     type: userTypes;
     description: string;
     emailNotificationsActivated: boolean;
-    emailNotificationsStatus: any;
+    emailNotificationsStatus;
     deleted: number | null;
     createdAt: number;
     expiredAt: number;
     resetPasswordRequests: IResetPasswordRequest[];
-    metadata?: any
+    metadata?
 }
 
 export interface IResetPasswordRequest {

--- a/packages/itmat-ui-react/src/components/apolloClient.ts
+++ b/packages/itmat-ui-react/src/components/apolloClient.ts
@@ -4,7 +4,7 @@ import { onError } from '@apollo/client/link/error';
 import createUploadLink from 'apollo-upload-client/createUploadLink.mjs';
 import axios from 'axios';
 
-const customFetch = (uri, options): any => {
+const customFetch = (uri, options) => {
     options.url = uri;
     options.data = options.body;
     if (options.body instanceof FormData) {
@@ -13,10 +13,10 @@ const customFetch = (uri, options): any => {
             if (currentOperation.operationName === 'uploadFile') {
                 const description = JSON.parse(currentOperation.variables.description);
                 options.onUploadProgress = (progressEvent) => {
-                    (window as any).onUploadProgressHackMap?.[`UP_${description.participantId}_${description.deviceId}_${description.startDate}_${description.endDate}`]?.(progressEvent);
+                    window.onUploadProgressHackMap?.[`UP_${description.participantId}_${description.deviceId}_${description.startDate}_${description.endDate}`]?.(progressEvent);
                 };
                 options.onDownloadProgress = (progressEvent) => {
-                    (window as any).onUploadProgressHackMap?.[`DOWN_${description.participantId}_${description.deviceId}_${description.startDate}_${description.endDate}`]?.(progressEvent);
+                    window.onUploadProgressHackMap?.[`DOWN_${description.participantId}_${description.deviceId}_${description.startDate}_${description.endDate}`]?.(progressEvent);
                 };
             }
         }
@@ -45,7 +45,7 @@ const uploadLink = createUploadLink({
     uri: `${window.location.origin}/graphql`,
     credentials: 'include',
     fetch: customFetch
-}) as any as ApolloLink;
+}) as ApolloLink;
 
 const cache = new InMemoryCache({
     dataIdFromObject: (object) => {
@@ -63,7 +63,7 @@ export const client = new ApolloClient({
     link: from([
         onError(({ response, graphQLErrors, networkError }) => {
             if (graphQLErrors) {
-                if ((response as any).errors[0].message === 'NOT_LOGGED_IN') {
+                if (response.errors[0].message === 'NOT_LOGGED_IN') {
                     window.location.reload();
                 }
                 graphQLErrors.map((error) =>

--- a/packages/itmat-ui-react/src/components/datasetDetail/tabContent/dashboard/jobs.tsx
+++ b/packages/itmat-ui-react/src/components/datasetDetail/tabContent/dashboard/jobs.tsx
@@ -6,7 +6,7 @@ import type { IJobEntry } from '@itmat-broker/itmat-types';
 import { GET_STUDY, SUBSCRIBE_TO_JOB_STATUS } from '@itmat-broker/itmat-models';
 import { Table, Button } from 'antd';
 
-const STATUSES: { [status: string]: any } = {
+const STATUSES: { [status: string] } = {
     finished: () => <td className={css.finishedStatus_td}><span>Finished</span></td>,
     // error: (errors: string[]) => <><span className={css.errorStatus_span}>Errored</span><InfoCircle/></>,
     error: (errors: string[]) => <td className={css.errorStatus_td}>
@@ -25,7 +25,7 @@ const STATUSES: { [status: string]: any } = {
     CANCELLED: () => <td className={css.cancelledStatus_td}><span>Cancelled</span></td>
 };
 
-// const JOBTYPES: { [type: string]: any } = {
+// const JOBTYPES: { [type: string] } = {
 //     DATA_UPLOAD_CSV: <span>Data upload</span>,
 //     DATA_UPLOAD_JSON: <span>Data upload json</span>,
 //     FIELD_INFO_UPLOAD: <span>Field annotation upload</span>
@@ -37,9 +37,9 @@ export const JobSection: FunctionComponent<{ studyId: string; jobs: Array<IJobEn
         {
             variables: { studyId }, onSubscriptionData: ({ client: store, subscriptionData }) => {
                 if (subscriptionData.data.subscribeToJobStatusChange !== null) {
-                    const olddata: any = store.readQuery({ query: GET_STUDY, variables: { studyId } });
+                    const olddata = store.readQuery({ query: GET_STUDY, variables: { studyId } });
                     const oldjobs = olddata.getStudy.jobs;
-                    const newjobs = oldjobs.map((el: any) => {
+                    const newjobs = oldjobs.map((el) => {
                         if (el.id === subscriptionData.data.subscribeToJobStatusChange.jobId) {
                             el.status = subscriptionData.data.subscribeToJobStatusChange.newStatus;
                             if (el.status === 'error') {

--- a/packages/itmat-ui-react/src/components/datasetDetail/tabContent/data/dataSummary.tsx
+++ b/packages/itmat-ui-react/src/components/datasetDetail/tabContent/data/dataSummary.tsx
@@ -25,7 +25,7 @@ export const DataSummaryVisual: FunctionComponent<{ studyId: string; selectedVer
 };
 
 ////////////////////////// COMPONENTS WITHIN THE PAGE//////////////////////////////////////
-const NumberOfPatients: FunctionComponent<{ data: any }> = ({ data }) => {
+const NumberOfPatients: FunctionComponent<{ data }> = ({ data }) => {
     return <div style={{ gridArea: 'patients' }}>
         <div>
             <p>Number of subjects</p>
@@ -38,7 +38,7 @@ const NumberOfPatients: FunctionComponent<{ data: any }> = ({ data }) => {
     </div>;
 };
 
-const NumberOfRecords: FunctionComponent<{ data: any }> = ({ data }) => {
+const NumberOfRecords: FunctionComponent<{ data }> = ({ data }) => {
     return <div style={{ gridArea: 'records' }}>
         <div>
             <p>Number of records</p>
@@ -59,7 +59,7 @@ const NewestVersionOfData: FunctionComponent<{ version: string, tag: string }> =
     </div>;
 };
 
-const NumberOfVisits: FunctionComponent<{ data: any }> = ({ data }) => {
+const NumberOfVisits: FunctionComponent<{ data }> = ({ data }) => {
     return <div style={{ gridArea: 'visits' }}>
         <div>
             <p>Number of visits</p>
@@ -75,7 +75,7 @@ const NumberOfVisits: FunctionComponent<{ data: any }> = ({ data }) => {
 const DateOfUpload: FunctionComponent<{ date: string | number /* UNIX timestamp */ }> = ({ date }) => {
     return <div style={{ gridArea: 'date' }}><div>
         <p>Data were uploaded on</p>
-        <span className={css.number_highlight}>{date ? (new Date(parseInt(date as any))).toLocaleString() : 'n/a'}</span>
+        <span className={css.number_highlight}>{date ? (new Date(parseInt(date))).toLocaleString() : 'n/a'}</span>
     </div></div>;
 };
 

--- a/packages/itmat-ui-react/src/components/datasetDetail/tabContent/data/dataTab.tsx
+++ b/packages/itmat-ui-react/src/components/datasetDetail/tabContent/data/dataTab.tsx
@@ -69,13 +69,13 @@ export const DataManagementTabContentFetch: FunctionComponent = () => {
         }
     ];
 
-    const versions: any = [];
+    const versions = [];
     for (const item of getStudyData.getStudy.dataVersions) {
         versions[item['version']] = item['id'];
     }
 
     //construct the cascader
-    const fieldPathOptions: any = [];
+    const fieldPathOptions = [];
     getOntologyTreeData.getOntologyTree.filter(el => el.id === treeId)[0]?.routes.forEach(el => {
         generateCascader(el, fieldPathOptions, false);
     });
@@ -175,7 +175,7 @@ export const DataManagementTabContentFetch: FunctionComponent = () => {
                                 if (error) { return <p>{JSON.stringify(error)}</p>; }
                                 if (!data) { return <p>Not executed.</p>; }
                                 const parsedData = getDataRecordsData.getDataRecords.data;
-                                const groupedData: any = {};
+                                const groupedData = {};
                                 for (const key in parsedData) {
                                     if (!(key in groupedData)) {
                                         groupedData[key] = [];

--- a/packages/itmat-ui-react/src/components/datasetDetail/tabContent/data/fieldListSelection.tsx
+++ b/packages/itmat-ui-react/src/components/datasetDetail/tabContent/data/fieldListSelection.tsx
@@ -38,7 +38,7 @@ export const FieldListSelectionSection: FunctionComponent<{ studyId: string; sel
     </>;
 };
 
-const FieldListSelectionState: FunctionComponent<{ studyId: string; fieldTreeIds: string[], studyData: any }> = ({ studyId, fieldTreeIds, studyData }) => {
+const FieldListSelectionState: FunctionComponent<{ studyId: string; fieldTreeIds: string[], studyData }> = ({ studyId, fieldTreeIds, studyData }) => {
     const [selectedTree, setSelectedTree] = useState(fieldTreeIds[0]);
 
     return <>

--- a/packages/itmat-ui-react/src/components/datasetDetail/tabContent/data/fieldTab.tsx
+++ b/packages/itmat-ui-react/src/components/datasetDetail/tabContent/data/fieldTab.tsx
@@ -63,7 +63,7 @@ export const FieldManagementTabContentFetch: FunctionComponent<{ studyId: string
         </p>;
     }
     const availableFormats: string[] = Array.from(new Set(getStandardizationData.getStandardization.map(el => el.type)));
-    const fieldPathOptions: any = [];
+    const fieldPathOptions = [];
     getOntologyTreeData.getOntologyTree.filter(el => el.name === format)[0]?.routes.forEach(el => {
         generateCascader(el, fieldPathOptions, true);
     });
@@ -87,7 +87,7 @@ export const FieldManagementTabContentFetch: FunctionComponent<{ studyId: string
             options={fieldPathOptions}
             placeholder={'Select Field'}
             onChange={(value) => {
-                const searchedRoute: any = getOntologyTreeData.getOntologyTree
+                const searchedRoute = getOntologyTreeData.getOntologyTree
                     .filter(el => el.name === format)[0].routes?.filter(el => JSON.stringify(el.path.concat(el.name)) === JSON.stringify(value))[0];
                 if (searchedRoute === undefined) {
                     return;

--- a/packages/itmat-ui-react/src/components/datasetDetail/tabContent/data/uploadNewData.tsx
+++ b/packages/itmat-ui-react/src/components/datasetDetail/tabContent/data/uploadNewData.tsx
@@ -47,7 +47,7 @@ const UploadNewDataForm: FunctionComponent<{ studyId: string; files: IFile[]; ca
             mode='multiple'
             onChange={(value) => {
                 const newArr: string[] = [];
-                for (let i = 0; i < (value as any).length; i++) {
+                for (let i = 0; i < value.length; i++) {
                     newArr.push(value[i].toString());
                 }
                 setSelectedFile(newArr);
@@ -67,7 +67,7 @@ const UploadNewDataForm: FunctionComponent<{ studyId: string; files: IFile[]; ca
             onCompleted={() => setSuccessfullySaved(true)}
         // update={(store, { data: { createDataCurationJob } }) => {
         //     // Read the data from our cache for this query.
-        //     const data: any = store.readQuery({ query: GET_STUDY, variables: { studyId } });
+        //     const data = store.readQuery({ query: GET_STUDY, variables: { studyId } });
         //     // Add our comment from the mutation to the end.
         //     const newjobs = data.getStudy.jobs.concat(createDataCurationJob);
         //     data.getStudy.jobs = newjobs;

--- a/packages/itmat-ui-react/src/components/datasetDetail/tabContent/data/uploadNewFields.tsx
+++ b/packages/itmat-ui-react/src/components/datasetDetail/tabContent/data/uploadNewFields.tsx
@@ -26,13 +26,13 @@ export const UploadNewFields: FunctionComponent<{ studyId: string }> = ({ studyI
             uploadFileTabSelected ?
                 <>
                     <br />
-                    <input title='file' type='file' ref={fileRef as any} />
+                    <input title='file' type='file' ref={fileRef} />
                     <Mutation<any, any> mutation={CREATE_FIELD_CURATION_JOB}>
                         {(createCurationJob, { loading }) => {
                             if (loading) { return <button>Loading...</button>; }
                             return (
                                 <button onClick={() => {
-                                    if ((fileRef.current as any).files.length === 1) {
+                                    if (fileRef.current.files.length === 1) {
                                         setError('');
                                         createCurationJob({
                                             variables: {
@@ -51,7 +51,7 @@ export const UploadNewFields: FunctionComponent<{ studyId: string }> = ({ studyI
                 :
                 <UploadFieldBySelectingFileFormFetch {...{ studyId, cancel: setExpanded }} />
         }
-    </div>;
+    </div >;
 };
 
 

--- a/packages/itmat-ui-react/src/components/datasetDetail/tabContent/files/fileTab.tsx
+++ b/packages/itmat-ui-react/src/components/datasetDetail/tabContent/files/fileTab.tsx
@@ -52,7 +52,7 @@ export const FileRepositoryTabContent: FunctionComponent<{ studyId: string }> = 
             const cachedata = store.readQuery({
                 query: GET_STUDY,
                 variables: { studyId }
-            }) as any;
+            });
             if (!cachedata)
                 return;
             const newcachedata = {
@@ -148,7 +148,7 @@ export const FileRepositoryTabContent: FunctionComponent<{ studyId: string }> = 
                 tup: file.tup?.trim().toUpperCase()
             };
             const uploadMapHackName = `UP_${description.participantId}_${description.deviceId}_${description.startDate}_${description.endDate}`;
-            if (!(window as any).onUploadProgressHackMap)
+            if (!((window as any).onUploadProgressHackMap))
                 (window as any).onUploadProgressHackMap = {};
             (window as any).onUploadProgressHackMap[uploadMapHackName] = (progressEvent) => {
                 setUploadMovement(Math.random);
@@ -341,12 +341,12 @@ export const FileRepositoryTabContent: FunctionComponent<{ studyId: string }> = 
         return [subjectLevelFiles, studyLevelFiles];
     }
 
-    const sortedFiles = dataSourceFilter(getStudyData.getStudy.files).sort((a, b) => parseInt((b as any).uploadTime) - parseInt((a as any).uploadTime));
+    const sortedFiles = dataSourceFilter(getStudyData.getStudy.files).sort((a: any, b: any) => parseInt(b.uploadTime) - parseInt(a.uploadTime));
     const numberOfFiles = sortedFiles[0].length;
-    const sizeOfFiles = sortedFiles[0].reduce((a, b) => a + (parseInt(b['fileSize'] as any) || 0), 0);
+    const sizeOfFiles = sortedFiles[0].reduce((a, b) => a + parseInt(b['fileSize'] || '0'), 0);
     const participantOfFiles = sortedFiles[0].reduce(function (values, v) {
         if (!values.set[JSON.parse(v['description'])['participantId']]) {
-            (values as any).set[JSON.parse(v['description'])['participantId']] = 1;
+            values.set[JSON.parse(v['description'])['participantId']] = 1;
             values.count++;
         }
         return values;
@@ -390,7 +390,7 @@ export const FileRepositoryTabContent: FunctionComponent<{ studyId: string }> = 
             tmpData.total = sortedFiles[0].filter(el => JSON.parse(el.description).participantId[0] === site).length;
             fileSummary.push(tmpData);
         }
-        const tmpData: any = {
+        const tmpData = {
             site: 'Total',
             total: sortedFiles[0].length
         };

--- a/packages/itmat-ui-react/src/components/datasetDetail/tabContent/projects/detailSections/deleteProjectSection.tsx
+++ b/packages/itmat-ui-react/src/components/datasetDetail/tabContent/projects/detailSections/deleteProjectSection.tsx
@@ -25,7 +25,7 @@ export const DeleteProjectSection: FunctionComponent<{ studyId: string; projectI
             mutation={DELETE_PROJECT}
             update={(store) => {
                 // Read the data from our cache for this query.
-                const data: any = store.readQuery({ query: GET_STUDY, variables: { studyId, admin: true } });
+                const data = store.readQuery({ query: GET_STUDY, variables: { studyId, admin: true } });
                 // Add our comment from the mutation to the end.
                 const newProjects = data.getStudy.projects.filter((el: IProject) => el.id !== projectId);
                 data.getStudy.projects = newProjects;
@@ -33,7 +33,7 @@ export const DeleteProjectSection: FunctionComponent<{ studyId: string; projectI
                 store.writeQuery({ query: GET_STUDY, variables: { studyId, admin: true }, data });
 
                 // Read the data from our cache for this query.
-                const whoAmI: any = store.readQuery({ query: WHO_AM_I });
+                const whoAmI = store.readQuery({ query: WHO_AM_I });
                 // Add our comment from the mutation to the end.
                 // const newWhoAmIProjects = whoAmI.whoAmI.access.projects.filter((el: IProject) => el.id !== projectId);
                 whoAmI.whoAmI.access.projects = newProjects;

--- a/packages/itmat-ui-react/src/components/datasetDetail/tabContent/projects/projectListSection.tsx
+++ b/packages/itmat-ui-react/src/components/datasetDetail/tabContent/projects/projectListSection.tsx
@@ -29,7 +29,7 @@ export const AddNewProject: FunctionComponent<{ studyId: string }> = ({ studyId 
         <Mutation<any, any> mutation={CREATE_PROJECT}
         // update={(store, { data: { createProject } }) => {
         //     // Read the data from our cache for this query.
-        //     const data: any = store.readQuery({ query: GET_STUDY, variables: { studyId, admin: true } });
+        //     const data = store.readQuery({ query: GET_STUDY, variables: { studyId, admin: true } });
         //     // Add our comment from the mutation to the end.
         //     const newProjects = data.getStudy.projects.concat(createProject);
         //     data.getStudy.projects = newProjects;
@@ -37,7 +37,7 @@ export const AddNewProject: FunctionComponent<{ studyId: string }> = ({ studyId 
         //     store.writeQuery({ query: GET_STUDY, variables: { studyId, admin: true }, data });
 
         //     // Read the data from our cache for this query.
-        //     const whoAmI: any = store.readQuery({ query: WHO_AM_I });
+        //     const whoAmI = store.readQuery({ query: WHO_AM_I });
         //     // Add our comment from the mutation to the end.
         //     // const newWhoAmIProjects = whoAmI.whoAmI.access.projects.concat(createProject);
         //     whoAmI.whoAmI.access.projects = newProjects;

--- a/packages/itmat-ui-react/src/components/log/logList.tsx
+++ b/packages/itmat-ui-react/src/components/log/logList.tsx
@@ -44,12 +44,12 @@ const LogList: FunctionComponent<{ list: ILogEntry[] }> = ({ list }) => {
         status: [],
         dateRange: ['', '']
     };
-    const [inputs, setInputs]: [{ [key: string]: any }, any] = useState(initInputs);
+    const [inputs, setInputs]: [{ [key: string] }, any] = useState(initInputs);
     const [verbose, setVerbose] = useState(false);
     const [verboseInfo, setVerboseInfo] = useState(({ actionData: JSON.stringify({}) }));
     const [advancedSearch, setAdvancedSearch] = useState(false);
     const dateFormat = 'YYYY-MM-DD';
-    function formatActionData(data: any) {
+    function formatActionData(data) {
         const obj = JSON.parse(data.actionData);
         const keys = Object.keys(obj);
         const keysMap = keys.map((el) => <><span>{el}</span><br /></>);
@@ -61,21 +61,21 @@ const LogList: FunctionComponent<{ list: ILogEntry[] }> = ({ list }) => {
 
     const inputControl = (property: string) => ({
         value: inputs[property],
-        onChange: (e: any) => {
+        onChange: (e) => {
             setInputs({ ...inputs, [property]: property === 'requesterName' ? e.target.value : e });
         }
     });
 
     const checkboxControl = (property: string) => ({
         value: inputs[property],
-        onChange: (e: any) => {
+        onChange: (e) => {
             setInputs({ ...inputs, [property]: e });
         }
     });
     function dataSourceFilter(logList: ILogEntry[]) {
         return logList.filter((log) => {
             // convert the contest of log to be string (except for value), as null could not be parsed
-            const logCopy: any = { ...log };
+            const logCopy = { ...log };
             Object.keys(logCopy).forEach(item => {
                 logCopy[item] = (logCopy[item] || '').toString();
             });

--- a/packages/itmat-ui-react/src/components/profile/profile.tsx
+++ b/packages/itmat-ui-react/src/components/profile/profile.tsx
@@ -231,7 +231,7 @@ export const showTimeFunc = {
 
 /* More time control due to different behaviors in chrome and firefox, also correct errors of summer/winter time offset */
 export const changeTimeFunc = {
-    changeDate: function (inputs: any, value: any) {
+    changeDate: function (inputs, value) {
         /* When in summer time, there is non-zero timezoneoffset which should be considered */
         const offsetTime = new Date(inputs.expiredAt - new Date(inputs.expiredAt).getTimezoneOffset() * 60 * 1000);
         let newDate;
@@ -244,7 +244,7 @@ export const changeTimeFunc = {
         }
         return { ...inputs, expiredAt: newDate.valueOf() };
     },
-    changeTime: function (inputs: any, value: any) {
+    changeTime: function (inputs, value) {
         const recordedDate = new Date(inputs.expiredAt).toISOString().substring(0, 10);
         /* When in summer time, there is non-zero timezoneoffset which should be considered */
         return { ...inputs, expiredAt: new Date(recordedDate + 'T' + value).valueOf() - new Date(inputs.expiredAt).getTimezoneOffset() * 60 * 1000 };

--- a/packages/itmat-ui-react/src/components/projectDetail/tabContent/analysis/analysisTab.tsx
+++ b/packages/itmat-ui-react/src/components/projectDetail/tabContent/analysis/analysisTab.tsx
@@ -60,15 +60,15 @@ export const AnalysisTabContent: FunctionComponent<{ studyId: string }> = ({ stu
         return <span>Ontology Tree Missing!</span>;
     }
 
-    const fieldPathOptions: any = [];
+    const fieldPathOptions = [];
     getOntologyTreeData.getOntologyTree[0]?.routes.forEach(el => {
         generateCascader(el, fieldPathOptions, true);
     });
 
-    const genderField: any = findDmField(getOntologyTreeData.getOntologyTree[0], getStudyFieldsData.getStudyFields, 'SEX');
-    const raceField: any = findDmField(getOntologyTreeData.getOntologyTree[0], getStudyFieldsData.getStudyFields, 'RACE');
-    const ageField: any = findDmField(getOntologyTreeData.getOntologyTree[0], getStudyFieldsData.getStudyFields, 'AGE');
-    const siteField: any = findDmField(getOntologyTreeData.getOntologyTree[0], getStudyFieldsData.getStudyFields, 'SITE');
+    const genderField = findDmField(getOntologyTreeData.getOntologyTree[0], getStudyFieldsData.getStudyFields, 'SEX');
+    const raceField = findDmField(getOntologyTreeData.getOntologyTree[0], getStudyFieldsData.getStudyFields, 'RACE');
+    const ageField = findDmField(getOntologyTreeData.getOntologyTree[0], getStudyFieldsData.getStudyFields, 'AGE');
+    const siteField = findDmField(getOntologyTreeData.getOntologyTree[0], getStudyFieldsData.getStudyFields, 'SITE');
     const results = divideResults(filters, getDataRecordsData?.getDataRecords.data, getStudyFieldsData.getStudyFields,
         [genderField, raceField, ageField, siteField]);
     return (<div className={css.tab_page_wrapper}>
@@ -77,7 +77,7 @@ export const AnalysisTabContent: FunctionComponent<{ studyId: string }> = ({ stu
             ontologyTree={getOntologyTreeData.getOntologyTree[0]} fieldPathOptions={fieldPathOptions} dmFields={[genderField, raceField, ageField, siteField]} />
         <br />
         {
-            (results && results.length) > 0 ?
+            (results?.length ?? 0) > 0 ?
                 <ResultsVisualization project={getProjectData.getProject} fields={getStudyFieldsData.getStudyFields} data={results} />
                 :
                 null
@@ -85,7 +85,7 @@ export const AnalysisTabContent: FunctionComponent<{ studyId: string }> = ({ stu
     </div>);
 };
 
-const FilterSelector: FunctionComponent<{ guideTool: any, filtersTool: any, fields: IFieldEntry[], project: IProject, query: any, ontologyTree: IOntologyTree, fieldPathOptions: any, dmFields: any[] }> = ({ guideTool, filtersTool, fields, project, query, ontologyTree, fieldPathOptions, dmFields }) => {
+const FilterSelector: FunctionComponent<{ guideTool, filtersTool, fields: IFieldEntry[], project: IProject, query, ontologyTree: IOntologyTree, fieldPathOptions, dmFields: any[] }> = ({ guideTool, filtersTool, fields, project, query, ontologyTree, fieldPathOptions, dmFields }) => {
     const [isModalOn, setIsModalOn] = useState(false);
     const [isTemplateModalOn, setIsTemplateModalOn] = useState(false);
     const [templateType, setTemplateType] = useState<string | undefined>('NA');
@@ -450,7 +450,7 @@ const FilterSelector: FunctionComponent<{ guideTool: any, filtersTool: any, fiel
     </div >);
 };
 
-const ResultsVisualization: FunctionComponent<{ project: IProject, fields: IFieldEntry[], data: any }> = ({ project, fields, data }) => {
+const ResultsVisualization: FunctionComponent<{ project: IProject, fields: IFieldEntry[], data }> = ({ project, fields, data }) => {
     const [statisticsType, setStatisticsType] = useState('ttest');
     const [signifianceLevel, setSignigicanceLevel] = useState<number | undefined>(undefined);
     if (data === undefined) {
@@ -482,7 +482,7 @@ const ResultsVisualization: FunctionComponent<{ project: IProject, fields: IFiel
             key: 'field',
             render: (__unused__value, record) => {
                 const thisField = fields.filter(el => el.fieldId === record.field)[0];
-                const data: any = [];
+                const data: any[] = [];
                 data.push({
                     key: 'Field Name',
                     value: <Tooltip title={thisField.fieldName}>
@@ -709,7 +709,7 @@ const ResultsVisualization: FunctionComponent<{ project: IProject, fields: IFiel
     </div>);
 };
 
-function variableFilterColumns(guideTool: any, fields: IFieldEntry[], remove: any, fieldPathOptions: any) {
+function variableFilterColumns(guideTool, fields: IFieldEntry[], remove, fieldPathOptions) {
     return [
         {
             title: 'Field',
@@ -793,7 +793,7 @@ function variableFilterColumns(guideTool: any, fields: IFieldEntry[], remove: an
     ];
 }
 
-function filterTableColumns(guideTool: any, fields: IFieldEntry[], dmFields: any[], filtersTool?: any, setIsModalOn?: any, setCurrentGroupIndex?: any) {
+function filterTableColumns(guideTool, fields: IFieldEntry[], dmFields: any[], filtersTool?, setIsModalOn?, setCurrentGroupIndex?) {
     if (filtersTool[0].groups.length === 0) {
         return [];
     }
@@ -890,7 +890,7 @@ function filterTableColumns(guideTool: any, fields: IFieldEntry[], dmFields: any
                         return null;
                     }
                     const filterFields: string[] = Array.from(new Set(record.filters.map(el => {
-                        const field: any = fields.filter(es => es.fieldId === el.field)[0];
+                        const field = fields.filter(es => es.fieldId === el.field)[0];
                         return field.fieldId.concat('-').concat(field.fieldName).concat(' ').concat(el.op).concat(' ').concat(el.value);
                     })));
                     return <div>
@@ -978,7 +978,7 @@ function filterTableColumns(guideTool: any, fields: IFieldEntry[], dmFields: any
     return columns;
 }
 
-function formInitialValues(form: any, filters: any, index: number) {
+function formInitialValues(form, filters, index: number) {
     if (index === -1) {
         return {
             visit: null,
@@ -995,7 +995,7 @@ function formInitialValues(form: any, filters: any, index: number) {
 }
 
 // // we sent the union of the filters as the filters in the request body
-function combineFilters(fields: IFieldEntry[], filters: any, dmFields: any[]) {
+function combineFilters(fields: IFieldEntry[], filters, dmFields: any[]) {
     const queryString: any = {};
     queryString.data_requested = Array.from(new Set((filters.groups.map(el => el.filters).flat().map(es => es.field).concat(filters.comparedFields)
         .concat(dmFields.filter(el => (el !== undefined && el !== null)).map(el => el.fieldId)))));
@@ -1023,8 +1023,8 @@ function divideResults(filters, results, fields, dmFields: any[]) {
     if (filters === undefined || results === undefined || fields === undefined) {
         return;
     }
-    const data: any = [];
-    const dms: any = {
+    const data: any[] = [];
+    const dms = {
         genderID: dmFields[0],
         race: dmFields[1],
         age: dmFields[2],
@@ -1132,7 +1132,7 @@ function divideResults(filters, results, fields, dmFields: any[]) {
         });
         // construct data for visualization
         if ([enumValueType.INTEGER, enumValueType.DECIMAL].includes(fieldDef.dataType)) {
-            const dataForGraph: any = Object.keys(dataClip.data).reduce((acc, curr) => {
+            const dataForGraph = Object.keys(dataClip.data).reduce((acc, curr) => {
                 dataClip.data[curr].forEach(el => {
                     acc.push({
                         x: curr,
@@ -1140,11 +1140,11 @@ function divideResults(filters, results, fields, dmFields: any[]) {
                     });
                 });
                 return acc;
-            }, ([] as any));
+            }, [] as any[]);
             dataClip.dataForGraph = dataForGraph;
         } else if ([enumValueType.CATEGORICAL, enumValueType.BOOLEAN].includes(fieldDef.dataType)) {
-            const dataForGraph: any = Object.keys(dataClip.data).reduce((acc, curr) => {
-                if (fieldDef.possibleValues !== undefined) {
+            const dataForGraph = Object.keys(dataClip.data).reduce((acc, curr) => {
+                if (fieldDef.possibleValues) {
                     fieldDef.possibleValues.forEach(ek => {
                         acc.push({
                             x: curr,
@@ -1156,7 +1156,7 @@ function divideResults(filters, results, fields, dmFields: any[]) {
                     return acc;
                 }
                 return acc;
-            }, ([] as any));
+            }, [] as any[]);
             dataClip.dataForGraph = dataForGraph;
         }
         // construct data for statistics

--- a/packages/itmat-ui-react/src/components/projectDetail/tabContent/data/dataTab.tsx
+++ b/packages/itmat-ui-react/src/components/projectDetail/tabContent/data/dataTab.tsx
@@ -189,10 +189,10 @@ export const MetaDataBlock: FunctionComponent<{ project: IProject, numOfOntology
 export const DemographicsBlock: FunctionComponent<{ ontologyTree: IOntologyTree, studyId: string, projectId: string, fields: IFieldEntry[] }> = ({ ontologyTree, studyId, projectId, fields }) => {
     const [width, __unused__height__] = useWindowSize();
     // process the data
-    const genderField: any = findDmField(ontologyTree, fields, 'SEX');
-    const raceField: any = findDmField(ontologyTree, fields, 'RACE');
-    const ageField: any = findDmField(ontologyTree, fields, 'AGE');
-    const siteField: any = findDmField(ontologyTree, fields, 'SITE');
+    const genderField = findDmField(ontologyTree, fields, 'SEX');
+    const raceField = findDmField(ontologyTree, fields, 'RACE');
+    const ageField = findDmField(ontologyTree, fields, 'AGE');
+    const siteField = findDmField(ontologyTree, fields, 'SITE');
 
     const { loading: getDataRecordsLoading, error: getDataRecordsError, data: getDataRecordsData } = useQuery(GET_DATA_RECORDS, {
         variables: {
@@ -414,7 +414,7 @@ export const DataDistributionBlock: FunctionComponent<{ ontologyTree: IOntologyT
         return el.fieldId.toString() === routes[0]?.field[0]?.replace('$', '');
     })[0];
     //construct the cascader
-    const fieldPathOptions: any = [];
+    const fieldPathOptions = [];
     ontologyTree.routes?.forEach(el => {
         generateCascader(el, fieldPathOptions, true);
     });
@@ -571,7 +571,7 @@ export const DataDistributionBlock: FunctionComponent<{ ontologyTree: IOntologyT
                                         acc.push({ x: curr, y: el });
                                     });
                                     return acc;
-                                }, ([] as any));
+                                }, [] as any);
                             } else if ([enumValueType.CATEGORICAL, enumValueType.BOOLEAN].includes(fields.filter(el => el.fieldId === fieldIdFromData)[0].dataType)) {
                                 data = Object.keys(data.getDataRecords.data[fieldIdFromData]).reduce((acc, curr) => {
                                     let count = 0;
@@ -590,7 +590,7 @@ export const DataDistributionBlock: FunctionComponent<{ ontologyTree: IOntologyT
                                         acc.push({ visit: curr, value: 'No Record', count: project.summary.subjects.length - count });
                                     }
                                     return acc;
-                                }, ([] as any)).sort((a, b) => { return parseFloat(a.value) - parseFloat(b.value); });
+                                }, [] as any).sort((a, b) => { return parseFloat(a.value) - parseFloat(b.value); });
                             } else {
                                 return null;
                             }
@@ -727,10 +727,10 @@ export const DataCompletenessBlock: FunctionComponent<{ studyId: string, project
             }
         }
     };
-    const tooltipConfig: any = {
+    const tooltipConfig = {
         showTitle: false,
         fields: ['visit', 'field', 'percentage'],
-        formatter: (datum: any) => {
+        formatter: (datum) => {
             const field: IFieldEntry | undefined = fields.filter(el => el.fieldId === datum.field)[0];
             let name;
             if (field) {
@@ -745,7 +745,7 @@ export const DataCompletenessBlock: FunctionComponent<{ studyId: string, project
         }
     };
     //construct the cascader
-    const fieldPathOptions: any = [];
+    const fieldPathOptions = [];
     ontologyTree.routes?.forEach(el => {
         generateCascader(el, fieldPathOptions, false);
     });
@@ -774,7 +774,7 @@ export const DataCompletenessBlock: FunctionComponent<{ studyId: string, project
                         renderer={'svg'}
                         colorField={'percentage'}
                         label={{
-                            formatter: (datum: any) => {
+                            formatter: (datum) => {
                                 return datum.percentage + '%';
                             }
                         }}

--- a/packages/itmat-ui-react/src/components/projectDetail/tabContent/utils/defaultParameters.ts
+++ b/packages/itmat-ui-react/src/components/projectDetail/tabContent/utils/defaultParameters.ts
@@ -1,4 +1,4 @@
-export const options: any = {
+export const options = {
     ops: ['=', '!=', '<', '>', '>=', '<='],
     tagColors: {
         visit: 'red',
@@ -15,10 +15,10 @@ export const statisticsTypes: string[] = [
     'ttest', 'ztest'
 ];
 
-export const analysisTemplate: any = {
+export const analysisTemplate = {
 };
 
-export const dataTypeMapping: any = {
+export const dataTypeMapping = {
     int: 'Integer',
     dec: 'Decimal',
     str: 'String',

--- a/packages/itmat-ui-react/src/components/reusable/fieldList/fieldList.tsx
+++ b/packages/itmat-ui-react/src/components/reusable/fieldList/fieldList.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import { enumValueType, IFieldEntry } from '@itmat-broker/itmat-types';
 import { Table, Tooltip } from 'antd';
 
-export const FieldListSection: FunctionComponent<{ studyData?: any, onCheck?: any; checkedList?: string[]; checkable: boolean; fieldList: IFieldEntry[]; verbal?: boolean }> = ({ onCheck, checkedList, checkable, fieldList, verbal }) => {
+export const FieldListSection: FunctionComponent<{ studyData?, onCheck?; checkedList?: string[]; checkable: boolean; fieldList: IFieldEntry[]; verbal?: boolean }> = ({ onCheck, checkedList, checkable, fieldList, verbal }) => {
     const possibleValuesColumns = [
         {
             title: 'Code',

--- a/packages/itmat-ui-react/src/components/reusable/fileList/fileList.tsx
+++ b/packages/itmat-ui-react/src/components/reusable/fileList/fileList.tsx
@@ -54,7 +54,7 @@ export const FileList: FunctionComponent<{ files: IFile[], searchTerm: string | 
         return <LoadSpinner />;
 
     if (getOrgsError || getUsersError)
-        return <>An error occured, please contact your administrator: {(getOrgsError as any).message} {(getUsersError as any).message}</>;
+        return <>An error occured, please contact your administrator: {getOrgsError.message} {getUsersError.message}</>;
 
     const userIdNameMapping = getUsersData.getUsers.reduce((a, b) => { a[b['id']] = b['firstname'].concat(' ').concat(b['lastname']); return a; }, {});
 

--- a/packages/itmat-ui-react/src/components/reusable/roleControlSection/roleControlSection.tsx
+++ b/packages/itmat-ui-react/src/components/reusable/roleControlSection/roleControlSection.tsx
@@ -455,7 +455,7 @@ type UsersControlPanelProps = {
     projectId?: string;
     availableUserList: IUser[];
     originallySelectedUsers: IUser[];
-    permissions: any;
+    permissions;
 }
 
 const UsersControlPanel: FunctionComponent<UsersControlPanelProps> = ({
@@ -494,7 +494,7 @@ const UsersControlPanel: FunctionComponent<UsersControlPanelProps> = ({
         });
     };
 
-    const handleFilter = (value: string, option: any) => {
+    const handleFilter = (value: string, option) => {
         const searchTerm = value?.trim()?.toLocaleLowerCase();
         const user = availableUserList.filter(user => user.id === option.value)?.[0];
         if (!user || !searchTerm || searchTerm === '')

--- a/packages/itmat-ui-react/src/components/reusable/subsection/subsection.tsx
+++ b/packages/itmat-ui-react/src/components/reusable/subsection/subsection.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import css from './subsection.module.css';
 
-export const Subsection: FunctionComponent<{ title: any; children: any }> = ({ title, children }) => {
+export const Subsection: FunctionComponent<{ title; children }> = ({ title, children }) => {
     return <div className={css.content_section}>
         <h5>{title}</h5>
         <div>
@@ -10,7 +10,7 @@ export const Subsection: FunctionComponent<{ title: any; children: any }> = ({ t
     </div>;
 };
 
-export const SubsectionWithComment: FunctionComponent<{ title: any; comment: any; children: any; float?: any }> = ({ title, comment, children, float }) => {
+export const SubsectionWithComment: FunctionComponent<{ title; comment; children; float?}> = ({ title, comment, children, float }) => {
     return <div className={css.content_section}>
         <h5>{title} <span style={{ float: float ? float : 'right', whiteSpace: 'pre' }}>{comment}</span></h5>
         <div>

--- a/packages/itmat-ui-react/src/components/users/userDetails.tsx
+++ b/packages/itmat-ui-react/src/components/users/userDetails.tsx
@@ -271,7 +271,7 @@ export const showTimeFunc = {
 
 /* More time control due to different behaviors in chrome and firefox, also correct errors of summer/winter time offset */
 export const changeTimeFunc = {
-    changeDate: function (inputs: any, value: any) {
+    changeDate: function (inputs, value) {
         /* When in summer time, there is non-zero timezoneoffset which should be considered */
         const offsetTime = new Date(inputs.expiredAt - new Date(inputs.expiredAt).getTimezoneOffset() * 60 * 1000);
         let newDate;
@@ -284,7 +284,7 @@ export const changeTimeFunc = {
         }
         return { ...inputs, expiredAt: newDate.valueOf() };
     },
-    changeTime: function (inputs: any, value: any) {
+    changeTime: function (inputs, value) {
         const recordedDate = new Date(inputs.expiredAt).toISOString().substring(0, 10);
         /* When in summer time, there is non-zero timezoneoffset which should be considered */
         return { ...inputs, expiredAt: new Date(recordedDate + 'T' + value).valueOf() - new Date(inputs.expiredAt).getTimezoneOffset() * 60 * 1000 };

--- a/packages/itmat-ui-react/src/global.d.ts
+++ b/packages/itmat-ui-react/src/global.d.ts
@@ -1,0 +1,5 @@
+declare global {
+    interface Window {
+        onUploadProgressHackMap?: Record<string, (progressEvent: any) => void>;
+    }
+}

--- a/packages/itmat-ui-react/src/index.tsx
+++ b/packages/itmat-ui-react/src/index.tsx
@@ -18,7 +18,7 @@ const mountApp = () => {
 mountApp();
 registerServiceWorker();
 
-declare const module: any;
+declare const module;
 if (module.hot) {
     module.hot.accept('./index', mountApp);
     module.hot.accept('./App', mountApp);

--- a/packages/itmat-ui-react/src/registerServiceWorker.ts
+++ b/packages/itmat-ui-react/src/registerServiceWorker.ts
@@ -94,7 +94,7 @@ function checkValidServiceWorker(swUrl: string) {
             // Ensure service worker exists, and that we really are getting a JS file.
             if (
                 response.status === 404 ||
-                response.headers.get('content-type')!.indexOf('javascript') === -1
+                response.headers.get('content-type').indexOf('javascript') === -1
             ) {
                 // No service worker found. Probably a different app. Reload the page.
                 navigator.serviceWorker.ready.then((registration) => {

--- a/packages/itmat-ui-react/src/utils/dmpCrypto/msrCrypto.d.ts
+++ b/packages/itmat-ui-react/src/utils/dmpCrypto/msrCrypto.d.ts
@@ -1,36 +1,36 @@
 declare namespace _default {
     export namespace subtle {
-        function encrypt(algorithm: any, keyHandle: any, buffer: any, ...args: any[]): Promise<any>;
-        function decrypt(algorithm: any, keyHandle: any, buffer: any, ...args: any[]): Promise<any>;
-        function sign(algorithm: any, keyHandle: any, buffer: any, ...args: any[]): Promise<any>;
-        function verify(algorithm: any, keyHandle: any, signature: any, buffer: any, ...args: any[]): Promise<any>;
-        function digest(algorithm: any, buffer: any, ...args: any[]): Promise<any>;
-        function generateKey(algorithm: any, extractable: any, keyUsage: any, ...args: any[]): Promise<any>;
-        function deriveKey(algorithm: any, baseKey: any, derivedKeyType: any, extractable: any, keyUsage: any): Promise<any>;
-        function deriveBits(algorithm: any, baseKey: any, length: any, ...args: any[]): Promise<any>;
-        function importKey(format: any, keyData: any, algorithm: any, extractable: any, keyUsage: any, ...args: any[]): Promise<any>;
-        function exportKey(format: any, keyHandle: any): Promise<any>;
-        function wrapKey(format: any, key: any, wrappingKey: any, wrappingKeyAlgorithm: any): Promise<any>;
-        function unwrapKey(format: any, wrappedKey: any, unwrappingKey: any, unwrapAlgorithm: any, unwrappedKeyAlgorithm: any, extractable: any, keyUsages: any): Promise<any>;
+        function encrypt(algorithm, keyHandle, buffer, ...args: any[]): Promise<any>;
+        function decrypt(algorithm, keyHandle, buffer, ...args: any[]): Promise<any>;
+        function sign(algorithm, keyHandle, buffer, ...args: any[]): Promise<any>;
+        function verify(algorithm, keyHandle, signature, buffer, ...args: any[]): Promise<any>;
+        function digest(algorithm, buffer, ...args: any[]): Promise<any>;
+        function generateKey(algorithm, extractable, keyUsage, ...args: any[]): Promise<any>;
+        function deriveKey(algorithm, baseKey, derivedKeyType, extractable, keyUsage): Promise<any>;
+        function deriveBits(algorithm, baseKey, length, ...args: any[]): Promise<any>;
+        function importKey(format, keyData, algorithm, extractable, keyUsage, ...args: any[]): Promise<any>;
+        function exportKey(format, keyHandle): Promise<any>;
+        function wrapKey(format, key, wrappingKey, wrappingKeyAlgorithm): Promise<any>;
+        function unwrapKey(format, wrappedKey, unwrappingKey, unwrapAlgorithm, unwrappedKeyAlgorithm, extractable, keyUsages): Promise<any>;
     }
-    export function getRandomValues(array: any): any;
-    export function initPrng(entropyData: any): void;
-    export function toBase64(data: any, base64Url: any): string;
-    export function fromBase64(base64String: any): number[];
-    export function textToBytes(text: any): any[];
-    export function bytesToText(byteArray: any): string;
+    export function getRandomValues(array);
+    export function initPrng(entropyData): void;
+    export function toBase64(data, base64Url): string;
+    export function fromBase64(base64String): number[];
+    export function textToBytes(text): any[];
+    export function bytesToText(byteArray): string;
     export { asn1 };
     export { scriptUrl as url };
     export { msrCryptoVersion as version };
-    export function useWebWorkers(useWebWorkers: any): any;
+    export function useWebWorkers(useWebWorkers);
 }
 export default _default;
 declare namespace asn1 {
     export { parse };
     export { encode };
-    export function toString(objTree: any): string;
+    export function toString(objTree): string;
 }
 declare let scriptUrl: string;
 declare let msrCryptoVersion: string;
-declare function parse(bytes: any, force: any): any;
-declare function encode(asn1tree: any): void;
+declare function parse(bytes, force);
+declare function encode(asn1tree): void;

--- a/packages/itmat-ui-react/src/utils/logUtils.tsx
+++ b/packages/itmat-ui-react/src/utils/logUtils.tsx
@@ -1,7 +1,7 @@
 import { LOG_ACTION, LOG_STATUS, userTypes } from '@itmat-broker/itmat-types';
 import { FetchResult } from '@apollo/client';
 
-export function logFun(mutationFunc: (__unused__data: { variables: any }) => Promise<FetchResult<any>>, whoamidata: any, type: LOG_ACTION, actionData: any, status: LOG_STATUS) {
+export function logFun(mutationFunc: (__unused__data: { variables }) => Promise<FetchResult<any>>, whoamidata, type: LOG_ACTION, actionData, status: LOG_STATUS) {
     if ('ERROR' in actionData) {
         actionData.ERROR = actionData.ERROR.graphQLErrors[0].message;
     }

--- a/packages/itmat-ui-react/src/utils/tools.ts
+++ b/packages/itmat-ui-react/src/utils/tools.ts
@@ -222,17 +222,17 @@ export function mannwhitneyu(x, y, alt, corr) {
     return { U: u.small, p: p };
 }
 
-export function generateCascader(root: any, array: any, includeEnd: boolean) {
+export function generateCascader(root, array, includeEnd: boolean) {
     if (!root) {
         return;
     }
-    let arrPointer: any = array;
+    let arrPointer = array;
     const path = [...root.path];
     if (includeEnd) {
         path.push(root.name);
     }
     for (const node of path) {
-        const obj = arrPointer.filter((el: { value: any; }) => el.value === node)[0];
+        const obj = arrPointer.filter((el: { value; }) => el.value === node)[0];
         if (!obj) {
             arrPointer.push({
                 value: node,
@@ -240,7 +240,7 @@ export function generateCascader(root: any, array: any, includeEnd: boolean) {
                 children: []
             });
         }
-        arrPointer = arrPointer.filter((el: { value: any; }) => el.value === node)[0].children;
+        arrPointer = arrPointer.filter((el: { value; }) => el.value === node)[0].children;
     }
 }
 


### PR DESCRIPTION
1. Replace the data type of `any` with other strict data types as possible;
2. Check the database availability to avoid non-null assertion;
3. The APIs should firstly check the user permission before any further operations.
4. Unify the errors. Use `ApolloError` only, and give details if possible.