### PR TITLE
fix: Make lxd initialization non-blocking and resilient

### DIFF
--- a/packages/itmat-cores/src/lxd/lxd.config.ts
+++ b/packages/itmat-cores/src/lxd/lxd.config.ts
@@ -186,6 +186,7 @@ export  const cloudInitUserDataMatlabContainer =  (instanceSystemToken: string, 
 #cloud-config
 packages:
   - davfs2
+  - nginx
 users:
   - name: ubuntu
     groups: sudo
@@ -308,6 +309,9 @@ write_files:
         }
     permissions: '0644'
 runcmd:
+  - ln -sf /etc/nginx/sites-available/vnc_proxy /etc/nginx/sites-enabled/
+  - systemctl enable nginx
+  - systemctl restart nginx
   - |
     DEFAULT_USER="\${USERNAME:-ubuntu}"
     if ! getent group nopasswdlogin > /dev/null; then

--- a/packages/itmat-ui-react/src/components/instance/instance.tsx
+++ b/packages/itmat-ui-react/src/components/instance/instance.tsx
@@ -261,14 +261,7 @@ export const InstanceSection: FunctionComponent = () => {
             <div className={css.marginBottom}>
                 <div style={{ marginTop: '10px' }} />
                 <Space size="large"> {}
-                    {/* <Button
-                        type="primary"
-                        size="large" // Increase the size for better emphasis
-                        style={{ backgroundColor: '#108ee9', borderColor: '#108ee9' }}
-                        onClick={() => setIsModalOpen(true)}
-                    >
-                    Create New Instance
-                    </Button> */}
+                    <h2 style={{ marginBottom: '0px' }}>My Instances</h2>
                     <Tooltip
                         title={
                             isAtOrOverQuota
@@ -286,7 +279,7 @@ export const InstanceSection: FunctionComponent = () => {
                             Create New Instance
                         </Button>
                     </Tooltip>
-                    <Button
+                    {/* <Button
                         type="default"
                         size="large" // Match the size with "Create New Instance" button
                         style={{
@@ -298,7 +291,7 @@ export const InstanceSection: FunctionComponent = () => {
                         rel="noopener noreferrer"
                     >
                     Go back to old AE v2
-                    </Button>
+                    </Button> */}
                 </Space>
 
             </div>


### PR DESCRIPTION
fix: Make lxd initialization non-blocking and resilient
- Improve LXD client initialization to continue when certificates are invalid
- Move connection testing out of startup sequence to prevent blocking
- Handle certificate loading errors gracefully
- Remove deprecated "old AE v2" button from UI